### PR TITLE
change from SSH to https for cloning instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ To clone the repository:
 
 .. code-block:: none
 
-  git clone git@github.com:icesat2py/icepyx.git
+  git clone https://github.com/icesat2py/icepyx.git
 
 
 Future developments of icepyx may include pip and conda as simplified installation options.

--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -22,7 +22,7 @@ To clone the repository:
 
 .. code-block:: none
 
-  git clone git@github.com:icesat2py/icepyx.git
+  git clone https://github.com/icesat2py/icepyx.git
 
 
 


### PR DESCRIPTION
This PR suggests a change from SSH to https in the instructions for cloning the repo. 