### PR TITLE
modify setup.py to allow pip install git+https

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -20,4 +20,4 @@ formats: all
 python:
   version: 3.7
   install:
-    - requirements: requirements.txt
+    - requirements: requirements-docs.txt

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,3 @@
+nbsphinx
+numpydoc
+-r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,5 @@ fiona
 geopandas
 h5py
 matplotlib
-nbsphinx
-numpydoc
 numpy
 shapely

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,10 @@
 import setuptools
 
-with open("README.rst", "r") as fh:
-    long_description = fh.read()
+with open("README.rst", "r") as f:
+    LONG_DESCRIPTION = f.read()
+
+with open("requirements.txt") as f:
+    INSTALL_REQUIRES = f.read().strip().split("\n")
 
 setuptools.setup(
     name="icepyx",
@@ -11,15 +14,17 @@ setuptools.setup(
     maintainer="Jessica Scheick",
     maintainer_email="jbscheick@gmail.com",
     description="Python tools for obtaining and working with ICESat-2 data",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
+    long_description=LONG_DESCRIPTION,
+    long_description_content_type="text/x-rst",
     url="https://github.com/icesat2py/icepyx.git",
-    packages=setuptools.find_packages(),
+    license="BSD 3-Clause",
+    packages=setuptools.find_packages(exclude=["*tests"]),
+    install_requires=INSTALL_REQUIRES,
+    python_requires=">=3",
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Development Status :: 1 - Planning",
-        
     ],
 )


### PR DESCRIPTION
Closes https://github.com/icesat2py/icepyx/issues/45

@JessicaS11 @dshean once merged people will be able to install the master branch with (add -e) for development mode:
```
pip install git+https://github.com/icesat2py/icepyx.git#egg=icepyx
```

I created a new `requirements-docs.txt` for readthedocs. This way `requirements.txt` defines just runtime dependencies for people using icepyx (not development dependencies needed for packaging, documentation, etc). 

Feel free to open PRs for the icesat2 hackweek image to install icepyx or other libraries (in editable mode or otherwise) https://github.com/ICESAT-2HackWeek/jupyter-image-2020/blob/master/environment.yml 


