### PR TITLE
Unzip hdf5 files into one directory instead of many

### DIFF
--- a/icepyx/core/granules.py
+++ b/icepyx/core/granules.py
@@ -379,7 +379,10 @@ class Granules():
         #         #Note: extract the dataset to save it locally
         # if extract is True:    
             with zipfile.ZipFile(io.BytesIO(zip_response.content)) as z:
-                z.extractall(path)
+                for zfile in z.filelist:
+                    # Remove the subfolder name from the filepath
+                    zfile.filename = os.path.basename(zfile.filename)
+                    z.extract(member=zfile, path=path)
             
             # update the current finished order id and save to file
             with open(downid_fn,'w') as fid:


### PR DESCRIPTION
The downloaded zip file stores each HDF5 file in separate subfolders. This Pull Request fixes #33 by modifying the unzipping code so that the files are all in a single folder (the download folder set by the user). I.e. instead of having this:

- download_folder
  - 123456789
    - processed_ATL06_2019*.h5
  - 234567891
    - processed_ATL06_2019*.h5
  - 345678912
    - processed_ATL06_2019*.h5
  - 456789123
    - processed_ATL06_2019*.h5

The unzip will now do this:

- download_folder
    - processed_ATL06_2019*.h5
    - processed_ATL06_2019*.h5
    - processed_ATL06_2019*.h5
    - processed_ATL06_2019*.h5

There seems to be an `extract` argument (which takes a boolean True/False) that is commented out in the code, should I enable it?