### PR TITLE
Save orderIDs every 5 orders for orders larger than 10.

### DIFF
--- a/icepyx/core/granules.py
+++ b/icepyx/core/granules.py
@@ -188,8 +188,9 @@ class Granules():
         if subset is False:
             request_params = apifmt.combine_params(CMRparams, reqparams, {'agent':'NO'})
         else:
-            request_params = apifmt.combine_params(CMRparams, reqparams, subsetparams)
+            request_params = apifmt.combine_params(CMRparams, reqparams, subsetparams)        
         
+        order_fn = '.order_restart'
         
         print('Total number of data order requests is ',request_params['page_num'], ' for ',len(self.avail), ' granules.')
         #DevNote/05/27/20/: Their page_num values are the same, but use the combined version anyway.
@@ -290,10 +291,17 @@ class Granules():
         
         #DevGoal: save orderIDs more frequently than just at the end for large orders (e.g. for len(reqparams['page_num']) > 5 or 10 or something)
         #Save orderIDs to file to avoid resubmitting order in case kernel breaks down.
-        order_fn = '.order_restart'
+            # save orderIDs for every 5 orders when more than 10 orders are submitted. 
+            # DevNote: These numbers are hard coded for now. Consider to allow user to set them in future?
+            if reqparams['page_num']>=10 and i%5==0:
+                with open(order_fn,'w') as fid:
+                    json.dump({'orderIDs':self.orderIDs},fid)
+                    
+        # --- Output the final orderIDs            
         with open(order_fn,'w') as fid:
             json.dump({'orderIDs':self.orderIDs},fid)
-            
+
+
 
         return self.orderIDs
 


### PR DESCRIPTION
I might have misread the indent for the part to save orderIDs and thought orderIDs were save for every order. Now I have changed it to save every 5 orders for orders longer than 10 and save at the end as well. 
