### PR TITLE
Add authentication with netrc

### DIFF
--- a/icepyx/core/Earthdata.py
+++ b/icepyx/core/Earthdata.py
@@ -1,6 +1,7 @@
 import requests
 import getpass
 import socket
+import netrc
 import re
 import json
 
@@ -25,7 +26,7 @@ class Earthdata():
     -------
     Earthdata session object after a successful login
     """
-        
+
     def __init__(
         self,
         uid,
@@ -33,10 +34,11 @@ class Earthdata():
         capability_url,
         pswd=None,
     ):
-        
+
         assert isinstance(uid, str), "Enter your login user id as a string"
         assert re.match(r'[^@]+@[^@]+\.[^@]+',email), "Enter a properly formatted email address"
-        
+
+        self.netrc = None
         self.uid = uid
         self.email = email
         self.capability_url = capability_url
@@ -51,19 +53,19 @@ class Earthdata():
         data = {'token': {'username': self.uid, 'password': self.pswd,\
                           'client_id': 'NSIDC_client_id','user_ip_address': ip}
         }
-        
+
         response = None
         response = requests.post(token_api_url, json=data, headers={'Accept': 'application/json'})
-        
+
         #check for a valid login
         try:
             json.loads(response.content)['token']
-        except KeyError: 
+        except KeyError:
             try:
                 print(json.loads(response.content)['errors'])
             except KeyError:
                 print("There are no error messages, but an Earthdata login token was not successfully generated")
-        
+
         token = json.loads(response.content)['token']['id']
 
         session = requests.session()
@@ -80,33 +82,52 @@ class Earthdata():
         If the login fails, it will ask the user to re-enter their
         username and password up to five times to try and log in.
 
+        Alternatively, you can create a .netrc file in your $HOME directory
+        with the following line:
+
+        machine urs.earthdata.nasa.gov login <uid> password <password>
+
+        Where <uid> is your NASA Earthdata user ID and <password> is your password
+        Then change the permissions of that file to 600
+        This will allow you to have read and write access to the file
+        No other user can access the file
+            $ chmod 600 ~/.netrc
+        The function checks for this file to retrieve credentials, prior to
+        prompting for manual input.
+
         Examples
         --------
         >>> icepyx.core.Earthdata.Earthdata.login('sam.smith','sam.smith@domain.com')
         Earthdata Login password:  ········
         """
-        self.pswd = getpass.getpass('Earthdata Login password: ')
-        for i in range(5):
-            try:
-                session = self._start_session()
-                break
-            except KeyError:
-                self.uid = input("Please re-enter your Earthdata user ID: ")
-                self.pswd = getpass.getpass('Earthdata Login password: ')
-                i = i+1
-                
-        else:
-            raise RuntimeError("You could not successfully log in to Earthdata")
-        
+
+        try:
+            url = 'urs.earthdata.nasa.gov'
+            self.uid,_,self.pswd = netrc.netrc(self.netrc).authenticators(url)
+            session = self._start_session()
+
+        except:
+            self.pswd = getpass.getpass('Earthdata Login password: ')
+            for i in range(5):
+                try:
+                    session = self._start_session()
+                    break
+                except KeyError:
+                    self.uid = input("Please re-enter your Earthdata user ID: ")
+                    self.pswd = getpass.getpass('Earthdata Login password: ')
+                    i += 1
+            else:
+                raise RuntimeError("You could not successfully log in to Earthdata")
+
         return self.session
 
 
 #DevGoal: try turning this into a class that uses super... an initial attempt at portions of this is below
 """
 class Earthdata(requests.Session):
-        
+
     def __init__(self, uid = uid, email = email,pswd = None):
-        super(Earthdata, self).__init__() 
+        super(Earthdata, self).__init__()
 
         assert isinstance(uid, str), "Enter your login user id as a string"
         assert re.match(r'[^@]+@[^@]+\.[^@]+',email), "Enter a properly formatted email address"


### PR DESCRIPTION
This PR adds authentication via `netrc`.

To use this functionality, create a .netrc file in your $HOME directory with the following lines:
```
machine urs.earthdata.nasa.gov
login your_Earthdata_user_ID
password your_password
```
Then change the permissions of that file to 600 with `chmod 600 ~/.netrc`.

The function checks for this file to retrieve credentials, prior to prompting for manual input. Authentication must still be instantiated with `earthdata_login(earthdata_uid, email)`, but the password is pulled programmatically from the `.netrc` file.

closes #69 