### PR TITLE
Cmr scrolling search

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -14,4 +14,4 @@ order by last name) and are considered "The icepyx Developers":
 * [Ben Smith](https://github.com/smithb) - University of Washington
 * [Amy Steiker](https://github.com/asteiker) - NSIDC, University of Colorado
 * [Bidhyananda Yadav](https://github.com/bidhya) - Ohio State University
-
+* [Bruce Wallin](https://github.com/wallinb) - University of Colorado - NSIDC

--- a/icepyx/tests/test_granules.py
+++ b/icepyx/tests/test_granules.py
@@ -22,7 +22,7 @@ from icepyx.core.granules import Granules as Granules
 def test_granules_info():
     # reg_a = ipd.Icesat2Data('ATL06', [-55, 68, -48, 71], ['2019-02-20','2019-02-24'], version='3')
     # granules = reg_a.granules.avail
-    granules = [{'producer_granule_id': 'ATL06_20190221121851_08410203_003_01.h5',
+    entries = [{'producer_granule_id': 'ATL06_20190221121851_08410203_003_01.h5',
     'time_start': '2019-02-21T12:19:05.000Z',
     'orbit': {'ascending_crossing': '-40.35812957405553',
     'start_lat': '59.5',
@@ -386,10 +386,10 @@ def test_granules_info():
         'rel': 'http://esipfed.org/ns/fedsearch/1.1/documentation#',
         'hreflang': 'en-US',
         'href': 'https://doi.org/10.5067/ATLAS/ATL06.003'}]}]
-    obs = granules.info(granules)
+    obs = granules.info(entries)
 
-    exp = {'Number of available granules': 2, /
-            'Average size of granules (MB)': 46.49339485165, /
+    exp = {'Number of available granules': 2, 
+            'Average size of granules (MB)': 46.49339485165, 
             'Total size of all granules (MB)': 92.9867897033}
 
     assert obs==exp
@@ -408,7 +408,7 @@ def test_no_granules_in_search_results():
 def test_correct_granule_list_returned():
     reg_a = ipd.Icesat2Data('ATL06',[-55, 68, -48, 71],['2019-02-20','2019-02-28'], version='2')
     reg_a.avail_granules()
-    obs_grans = [gran['producer_granule_id'] for gran in reg_a.granules]
+    obs_grans = [gran['producer_granule_id'] for gran in reg_a.granules.avail]
     exp_grans = ['ATL06_20190221121851_08410203_002_01.h5', 'ATL06_20190222010344_08490205_002_01.h5', 'ATL06_20190225121032_09020203_002_01.h5', 'ATL06_20190226005526_09100205_002_01.h5']
     
     assert set(obs_grans) == set(exp_grans)

--- a/icepyx/tests/test_is2class_query.py
+++ b/icepyx/tests/test_is2class_query.py
@@ -1,10 +1,9 @@
-from icepyx import is2class as ipd
+import icepyx.core.icesat2data as ipd
 import pytest
 import warnings
 
 def test_CMRparams():
     reg_a = ipd.Icesat2Data('ATL06',[-64, 66, -55, 72],['2019-02-22','2019-02-28'])
-    reg_a.build_CMR_params()
     obs_keys = reg_a.CMRparams.keys()
     exp_keys_all = ['short_name','version','temporal']
     exp_keys_any = ['bounding_box','polygon']
@@ -16,17 +15,14 @@ def test_reqconfig_params():
     reg_a = ipd.Icesat2Data('ATL06',[-64, 66, -55, 72],['2019-02-22','2019-02-28'])
     
     #test for search params
-    reg_a.build_reqconfig_params('search')
     obs_keys = reg_a.reqparams.keys()
     exp_keys_all = ['page_size','page_num']    
     assert all(keys in obs_keys for keys in exp_keys_all)
 
     #test for download params
-    reg_a.reqparams=None
-    reg_a.build_reqconfig_params('download')
     reg_a.reqparams.update({'token':'','email':''})
     obs_keys = reg_a.reqparams.keys()
-    exp_keys_all = ['page_size','page_num','request_mode','token','email','include_meta']
+    exp_keys_all = ['page_size','page_num','token','email']
     assert all(keys in obs_keys for keys in exp_keys_all)
     
 def test_properties():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-datetime
 fiona
 geopandas
 h5py


### PR DESCRIPTION
Unfortunately EGI does not support scrolling yet, so this only updates granule search. 

Some thoughts: Ordering and querying could be less coupled than they are now e.g. `place_order` calls `get_avail` to know how many granules will be ordered, but the sub-setting service will do the similar search itself to fulfill the order. In some edge cases these two searches can become inconsistent with each other, especially now that one uses scrolling and one uses paging. At the moment it is the only way to know/estimate the number of pages/orders necessary so I left it as is. Maybe long term we want to separate 'querying' functionality from 'ordering' into separate classes or something?