### PR TITLE
Tj docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,24 +26,44 @@ This project combines and generalizes these scripts into a unified framework, ma
 
 
 .. _`zipped file`: https://github.com/icesat2py/icepyx/archive/master.zip
+.. _`Fiona`: https://pypi.org/project/Fiona/
 
 Installation
 ------------
-Currently icepyx is only available for use as a github repository.
-The contents of the repository can be download as a `zipped file`_ or cloned.
+The simplest way to install icepyx is using pip.
 
-To use icepyx, fork this repo to your own account, then ``git clone`` the repo onto your system.
-Provided the location of the repo is part of your $PYTHONPATH,
-you should simply be able to add ``import icepyx`` to your Python document.
+.. code-block::
 
+  pip install icepyx
+
+
+Windows users will need to first install `Fiona`_, please look at the instructions there. Windows users may consider installing Fiona using pipwin
+
+.. code-block::
+
+  pip install pipwin
+  pipwin install Fiona 
+
+
+Currently, packages are not automatically generated with each build, this means it is possible that pip will not install the latest release of icepyx. In this case, icepyx is also available for use via the GitHub repository. The contents of the repository can be download as a `zipped file`_ or cloned.
+
+To use icepyx this way, fork this repo to your own account, then git clone the repo onto your system. 
 To clone the repository:
 
-.. code-block:: none
+.. code-block::
 
   git clone https://github.com/icesat2py/icepyx.git
 
 
-Future developments of icepyx may include pip and conda as simplified installation options.
+Provided the location of the repo is part of your $PYTHONPATH, you should simply be able to add import icepyx to your Python document.
+Alternatively, in a command line or terminal, navigate to the folder in your cloned repository containing setup.py and run
+
+.. code-block::
+
+  pip install -e
+
+
+Future developments of icepyx may include conda as another simplified installation option.
 
 
 Examples (Jupyter Notebooks)

--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -2,7 +2,7 @@
 
 
 .. _`zipped file`: https://github.com/icesat2py/icepyx/archive/master.zip
-
+.. _`Fiona`: https://pypi.org/project/Fiona/
 
 
 
@@ -10,21 +10,37 @@
 Installation
 ============
 
+The simplest way to install icepyx is using pip.
 
-Currently icepyx is only available for use as a github repository.
-The contents of the repository can be download as a `zipped file`_ or cloned.
+.. code-block::
 
-To use icepyx, fork this repo to your own account, then ``git clone`` the repo onto your system.
-Provided the location of the repo is part of your $PYTHONPATH,
-you should simply be able to add ``import icepyx`` to your Python document.
+  pip install icepyx
 
+
+Windows users will need to first install `Fiona`_, please look at the instructions there. Windows users may consider installing Fiona using pipwin
+
+.. code-block::
+
+  pip install pipwin
+  pipwin install Fiona 
+
+
+Currently, packages are not automatically generated with each build, this means it is possible that pip will not install the latest release of icepyx. In this case, icepyx is also available for use via the GitHub repository. The contents of the repository can be download as a `zipped file`_ or cloned.
+
+To use icepyx this way, fork this repo to your own account, then git clone the repo onto your system. 
 To clone the repository:
 
-.. code-block:: none
+.. code-block::
 
   git clone https://github.com/icesat2py/icepyx.git
 
 
+Provided the location of the repo is part of your $PYTHONPATH, you should simply be able to add import icepyx to your Python document.
+Alternatively, in a command line or terminal, navigate to the folder in your cloned repository containing setup.py and run
+
+.. code-block::
+
+  pip install -e
 
 
-Future developments of icepyx may include pip and conda as simplified installation options.
+Future developments of icepyx may include conda as another simplified installation option.


### PR DESCRIPTION
Updated installation instructions for front-page on GitHub, including how icepyx can be installed with pip from the Python Package Index. Duplicated for readthedocs. 