### PR TITLE
add OpenAltimetry quick plotting

### DIFF
--- a/icepyx/tests/test_OpenAltimetry.py
+++ b/icepyx/tests/test_OpenAltimetry.py
@@ -1,0 +1,14 @@
+from icepyx import icesat2data as ipd
+
+
+def test_OA_request():
+    short_name = 'ATL06'
+    date_range = ['2018-10-14','2018-10-16']
+    bbox = [-121, 48, -120, 49]
+
+    region = ipd.Icesat2Data(short_name, bbox, date_range)
+
+    region.visualize_spatial_extent(OA_quickplot=True)
+    
+    assert region.OA_data.empty == False
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ matplotlib
 numpy
 requests
 shapely
+descartes


### PR DESCRIPTION
**Enhancement to enable quick plotting via data requests from OpenAltimetry.** 
- Adds `OA_request()` and `generate_OA_request_params()` functions to `Icesat2Data()` class. 
- Can be called by setting `region.visualize_spatial_extent(OA_quickplot=True)` 
- Default is `OA_quickplot=False`, so this should not impact existing workflows.
- Returned geopandas GeoDataFrame can be accessed via `region.OA_data`
- Test added under icepyx/icepyx/test/test_OpenAltimetry.py
**Notes:** 
- OpenAltimetry API will not return data that exceeds bounds of 5 degrees in the lat or lon dimension.
- Setting a broad request, such as `date_range = ['2018-10-14','2020-04-04']` and `spatial_extent = [-75, -76.5, -74.5, -76]` will return a large amount of data, which may take 1-2 minutes to complete. See icepyx/icepyx/test/test_OpenAltimetry.py for smaller request example.
closes #92