### PR TITLE
add try/except for gaierror to address #97

### DIFF
--- a/icepyx/core/Earthdata.py
+++ b/icepyx/core/Earthdata.py
@@ -47,8 +47,12 @@ class Earthdata():
     def _start_session(self):
         #Request CMR token using Earthdata credentials
         token_api_url = 'https://cmr.earthdata.nasa.gov/legacy-services/rest/tokens'
-        hostname = socket.gethostname()
-        ip = socket.gethostbyname(hostname)
+        #try initially with machine hostname
+        #revert to using localhost if gaierror exception
+        try:
+            ip = socket.gethostbyname(socket.gethostname())
+        except:
+            ip = socket.gethostbyname('localhost')
 
         data = {'token': {'username': self.uid, 'password': self.pswd,\
                           'client_id': 'NSIDC_client_id','user_ip_address': ip}


### PR DESCRIPTION
mac OS upgrades can lead to machines unable to get IP from hostname.  this is a fix to revert to using 'localhost' in case of a gaierror from socket.gethostbyname