### PR TITLE
[WIP] New files for putting icepyx examples on pangeo-gallery

### DIFF
--- a/.github/workflows/binderbot.yaml
+++ b/.github/workflows/binderbot.yaml
@@ -1,0 +1,76 @@
+name: Binderbot
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the master branch
+  push:
+    branches:
+      - master
+    paths:
+      - '**.ipynb'
+      - 'binder-gallery.yaml'
+      - 'thumbnail.png'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '**.ipynb'
+      - 'binder-gallery.yaml'
+      - 'thumbnail.png'
+
+jobs:
+  build:
+    name: Binderbot Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: parse config
+        id: parse
+        uses: CumulusDS/get-yaml-paths-action@v0.0.3
+        with:
+          file: binder-gallery.yaml
+          gallery_repository: gallery_repository
+          binder_url: binder_url
+          binder_repo: binder_repo
+          binder_ref: binder_ref
+          binderbot_target_branch: binderbot_target_branch
+      - name: Verify output
+        run: |
+          echo gallery_repository: "${{ steps.parse.outputs.gallery_repository }}"
+          echo binder_url: "${{ steps.parse.outputs.binder_url }}"
+          echo binder_repo: "${{ steps.parse.outputs.binder_repo }}"
+          echo binder_ref: "${{ steps.parse.outputs.binder_ref }}"
+          echo binderbot_target_branch: "${{ steps.parse.outputs.binderbot_target_branch }}"
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.8'
+          architecture: 'x64'
+      - name: Install Binderbot from github master
+        run: pip install git+https://github.com/pangeo-gallery/binderbot.git
+      - name: Create Clean Branch
+        run: |
+          git checkout --orphan ${{ steps.parse.outputs.binderbot_target_branch }}
+          git rm --cached -r .
+      - name: Build notebooks using Binderbot
+        run: |
+          python -m binderbot.cli \
+          --binder-url ${{ steps.parse.outputs.binder_url }} \
+          --repo ${{ steps.parse.outputs.binder_repo }} \
+          --ref ${{ steps.parse.outputs.binder_ref }} \
+          *.ipynb
+      - name: Commit files
+        if: github.ref == 'refs/heads/master'
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add binder-gallery.yaml thumbnail.png *.ipynb
+          git commit -m "Binderbot output"
+      - name: Push commit
+        if: github.ref == 'refs/heads/master'
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ steps.parse.outputs.binderbot_target_branch }}
+          force: true
+      - name: Trigger repository dispatch on Pangeo Gallery
+        if: github.ref == 'refs/heads/master'
+        run: curl -f https://pangeo-gallery-bot.herokuapp.com/gallery/submodule-dispatch/${{ github.repository }}

--- a/.github/workflows/lint_yaml.yaml
+++ b/.github/workflows/lint_yaml.yaml
@@ -1,0 +1,23 @@
+name: Lint Yaml
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - binder-gallery.yaml
+  pull_request:
+    branches:
+      - master
+    paths:
+      - binder-gallery.yaml
+
+jobs:
+  build:
+    name: Lint Yaml
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: jacobtomlinson/gha-lint-yaml@master
+      with:
+        path: binder-gallery.yaml
+        strict: true

--- a/binder-gallery.yaml
+++ b/binder-gallery.yaml
@@ -1,0 +1,9 @@
+---
+name: icepyx examples gallery
+description: >-
+  Examples using icepyx Python tools for obtaining and working with ICESat-2 data
+gallery_repository: pangeo-gallery/pangeo-gallery
+binder_url: "https://mybinder.org"
+binder_repo: icesat2py/icepyx
+binder_ref: master
+binderbot_target_branch: binderbot-built


### PR DESCRIPTION
This is the start of the work that will get some icepyx example notebooks onto [Pangeo Gallery](http://gallery.pangeo.io/). @JessicaS11 and I have had some conversation about what this will look like and we are now putting the conversation on GitHub.

This building of notebooks can be another entry point / set of learning resources for users new to Pangeo and ICESat-2. Some of this work may be relevant later for the icepyx gallery that would be on ReadTheDocs; binderbot can maybe be repurposed for that. Currently, we still need to choose / work on:

- [ ] a binderhub to build notebooks on. I've put mybinder.org as the default.
- [ ] a docker image to use as the computing environment for building the notebooks. `Dockerfile` is currently blank.
- [ ] an updated description in `binder-gallery.yaml` (if desired)
- [ ] what notebooks to build
- [ ] a mechanism for naming the notebooks that we want built (because we do not want all of the notebooks built). This should look like a wildcard-style pattern for file names and will replace `paths: - '**.ipynb'` in `.github/workflows/binderbot.yaml`.
- [ ] how to reference the desired thumbnail image in a way that isn't `thumbnail.png` at the root of the repo
- [ ] Adding this repo as a submodule to the Pangeo Gallery. I will set this up near the end via the instructions present in Pangeo Gallery's [Contributor Guide](http://gallery.pangeo.io/contributing.html).