### PR TITLE
fix PyPI build activation with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ deploy:
       secure: test_PyPI_API_Token
     on:
       all_branches: true
-      condition: commit_message =~ test_pypi
+#       condition: commit_message =~ test_pypi
     skip_existing: true
   - provider: pypi
     username: "__token__"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ jobs:
     #     - pytest icepyx/tests/behind_NSIDC_API_login.py
 
 deploy:
-  - provider: pypi-test
+  - provider: pypi
     server: https://test.pypi.org/legacy/ 
     username: "__token__"
     password: 
@@ -34,7 +34,8 @@ deploy:
     skip_existing: true
   - provider: pypi
     username: "__token__"
-    password: $PyPI_API_Token
+    password: 
+      secure: PyPI_API_Token
     on:
       branch: master
       tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ deploy:
       secure: test_PyPI_API_Token
     on:
       all_branches: true
-      condition: commit_message = test_pypi
+      condition: commit_message =~ test_pypi
     skip_existing: true
   - provider: pypi
     username: "__token__"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,13 @@ jobs:
     #     - pytest icepyx/tests/behind_NSIDC_API_login.py
 
 deploy:
-  - provider: pypi
+  - provider: pypi-test
     server: https://test.pypi.org/legacy/ 
     username: "__token__"
-    password: $test_PyPI_API_Token
+    password: 
+      secure: test_PyPI_API_Token
     on:
-#       branch: development
+      all_branches: true
       condition: commit_message = test_pypi
     skip_existing: true
   - provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ deploy:
     on:
       all_branches: true
 #       condition: commit_message =~ test_pypi
+    skip_clean: true
     skip_existing: true
   - provider: pypi
     username: "__token__"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
   include:
     - stage: basic tests
       script: pytest icepyx/ --ignore icepyx/tests/behind_NSIDC_API_login.py
-      after_success: codecov
+#       after_success: codecov
 
     # - stage: behind Earthdata
     #   script:
@@ -28,8 +28,8 @@ deploy:
     username: "__token__"
     password: $test_PyPI_API_Token
     on:
-      all_branches: true
-#       if: commit_message =~ test_pypi
+      branch: test_pypi_travis
+      if: commit_message =~ test_pypi
     skip_existing: true
   - provider: pypi
     username: "__token__"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,10 @@ deploy:
   - provider: pypi
     server: https://test.pypi.org/legacy/ 
     username: "__token__"
-    password: 
-      secure: test_PyPI_API_Token
+    password: $test_PyPI_API_Token
     on:
       all_branches: true
-#       condition: commit_message =~ test_pypi
-    skip_clean: true
+#       if: commit_message =~ test_pypi
     skip_existing: true
   - provider: pypi
     username: "__token__"

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ deploy:
     username: "__token__"
     password: $test_PyPI_API_Token
     on:
-      branch: development
+#       branch: development
       condition: commit_message = test_pypi
     skip_existing: true
   - provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
   include:
     - stage: basic tests
       script: pytest icepyx/ --ignore icepyx/tests/behind_NSIDC_API_login.py
-#       after_success: codecov
+      after_success: codecov
 
     # - stage: behind Earthdata
     #   script:
@@ -31,13 +31,13 @@ deploy:
       branch: test_pypi_travis
       if: commit_message =~ test_pypi
     skip_existing: true
+    distributions: "bdist_wheel"
   - provider: pypi
     username: "__token__"
     password: 
-      secure: PyPI_API_Token
+      secure: $PyPI_API_Token
     on:
       branch: master
       tags: true
     skip_existing: true
-#   script:
-#     - export PyPI_API_Token=$PyPI_API_Token
+    distributions: "bdist_wheel"

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,10 @@ deploy:
     username: "__token__"
     password: $test_PyPI_API_Token
     on:
-      branch: test_pypi_travis
+      branch: development
       if: commit_message =~ test_pypi
     skip_existing: true
-    distributions: "bdist_wheel"
+    distributions: "sdist bdist_wheel"
   - provider: pypi
     username: "__token__"
     password: 
@@ -40,4 +40,4 @@ deploy:
       branch: master
       tags: true
     skip_existing: true
-    distributions: "bdist_wheel"
+    distributions: "sdist bdist_wheel"

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt") as f:
 
 setuptools.setup(
     name="icepyx",
-    version="0.2.0",
+    version="0.3.0",
     author="The icepyx Developers",
     author_email="jbscheick@gmail.com",
     maintainer="Jessica Scheick",


### PR DESCRIPTION
The previous setup of releasing with a Travis post-build hook was erroring out (authentication and commit message flag issues). This PR fixes those issues and successfully triggers a wheel and source code distribution build on TestPyPI, as intended for the development branch.