### PR TITLE
add current path to pip install -e option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ Alternatively, in a command line or terminal, navigate to the folder in your clo
 
 .. code-block::
 
-  pip install -e
+  pip install -e .
 
 
 Future developments of icepyx may include conda as another simplified installation option.


### PR DESCRIPTION
This is a small documentation fix to the README file. The command line instruction for pip installing icepyx from the setup.py using the -e option is missing the required path, which in this case should be the current directory.