### PR TITLE
Added a publication to icepyx_pubs.bib

### DIFF
--- a/doc/source/tracking/icepyx_pubs.bib
+++ b/doc/source/tracking/icepyx_pubs.bib
@@ -1,6 +1,6 @@
 @misc{2020_IS2-HW-tutorials,
-  author       = {Arendt, Anthony and 
-  		 Scheick, Jessica and 
+  author       = {Arendt, Anthony and
+  		 Scheick, Jessica and
                   Shean, David and
                   Buckley, Ellen and
                   Grigsby, Shane and
@@ -38,4 +38,16 @@ title = {{Introducing} icepyx, an open source {Python} library for obtaining and
 year = {2019},
 comment = {abstract,poster},
 doi = {10.1002/essoar.10501423.1},
+}
+
+@Article{tc-14-3629-2020,
+AUTHOR = {Li, T. and Dawson, G. J. and Chuter, S. J. and Bamber, J. L.},
+TITLE = {Mapping the grounding zone of Larsen~C Ice Shelf, Antarctica, from ICESat-2 laser altimetry},
+JOURNAL = {The Cryosphere},
+VOLUME = {14},
+YEAR = {2020},
+NUMBER = {11},
+PAGES = {3629--3643},
+URL = {https://tc.copernicus.org/articles/14/3629/2020/},
+DOI = {10.5194/tc-14-3629-2020}
 }


### PR DESCRIPTION
Add a [publication](https://tc.copernicus.org/articles/14/3629/2020/tc-14-3629-2020.html) to the new icepyx docs page.