### PR TITLE
Add ability to access ATL11 Annual Land Ice Height data

### DIFF
--- a/icepyx/core/is2ref.py
+++ b/icepyx/core/is2ref.py
@@ -24,6 +24,7 @@ def _validate_dataset(dataset):
             "ATL08",
             "ATL09",
             "ATL10",
+            "ATL11",
             "ATL12",
             "ATL13",
         ], "Please enter a valid dataset"

--- a/icepyx/core/is2ref.py
+++ b/icepyx/core/is2ref.py
@@ -214,6 +214,14 @@ def _default_varlists(dataset):
             "height_segment_confidence",
         ]
 
+    elif dataset == "ATL11":
+        return common_list + [
+            "h_corr",
+            "h_corr_sigma",
+            "h_corr_sigma_systematic",
+            "quality_summary",
+        ]
+
     else:
         print(
             "THE REQUESTED DATASET DOES NOT YET HAVE A DEFAULT LIST SET UP. ONLY DELTA_TIME, LATITUTDE, AND LONGITUDE WILL BE RETURNED"

--- a/icepyx/tests/test_is2ref.py
+++ b/icepyx/tests/test_is2ref.py
@@ -186,3 +186,17 @@ def test_ATL09_default_varlist():
         "apparent_surf_reflec",
     ]
     assert obs == expected
+
+
+def test_ATL11_default_varlist():
+    obs = is2ref._default_varlists("ATL11")
+    expected = [
+        "delta_time",
+        "latitude",
+        "longitude",
+        "h_corr",
+        "h_corr_sigma",
+        "h_corr_sigma_systematic",
+        "quality_summary",
+    ]
+    assert obs == expected


### PR DESCRIPTION
Version 2 of the ATLAS/ICESat-2 L3B Annual Land Ice Height product (ATL11) was just released (see https://nsidc.org/the-drift/data-update/new-version-available-atlasicesat-2-l3b-annual-land-ice-height-version-2/), so thought I'd get this into `icepyx`! ATL11 is like ATL06, but a lot more lightweight. From https://nsidc.org/data/ATL11:

> This data set provides time series of land-ice surface heights derived from the ICESat-2 ATL06 Land-ice Height product. It is intended primarily as an input for higher level gridded products, but can also be used on its own as a spatially organized product that allows easy access to height-change information derived from ICESat-2 observations.

This PR is just a small start so that people trying to download ATL11 won't get a "Please enter a valid dataset" error. I've got a whole suite of ATL11 scripts lying around that I'll try to port over to `icepyx` sometime later this year :wink:

References:
- https://github.com/suzanne64/ATL11
- https://doi.org/10.5067/ATLAS/ATL11.002
- https://nsidc.org/sites/nsidc.org/files/technical-references/ICESat2_ATL11_data_dict_v002.pdf
- https://nsidc.org/sites/nsidc.org/files/technical-references/ICESat2_ATL11_ATBD_r002.pdf