### PR TITLE
Add a missing descartes dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ matplotlib
 numpy
 requests
 shapely
+descartes


### PR DESCRIPTION
It looks that (at least on my computer) the descartes package is required (for visualizing query area on map) but not specified in the requirement.txt.