### PR TITLE
Add header/parameters to enable metrics collection at NSIDC

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -23,5 +23,6 @@ order by last name) and are considered "The icepyx Developers":
 * `Ben Smith <https://github.com/smithb>`_ - University of Washington
 * `Amy Steiker <https://github.com/asteiker>`_ - NSIDC, University of Colorado
 * `Anna Valentine <https://github.com/annavalentine>`_ - Colorado School of Mines
+* `Bruce Wallin <https://github.com/wallinb>`_ - NSIDC, University of Colorado
 * `Molly Wieringa <https://github.com/mollymwieringa>`_ - University of Washington
 * `Bidhyananda Yadav <https://github.com/bidhya>`_ - Ohio State University

--- a/icepyx/core/APIformatting.py
+++ b/icepyx/core/APIformatting.py
@@ -251,6 +251,7 @@ class Parameters:
                     "token",
                     "email",
                     "include_meta",
+                    "client_string",
                 ],
             }
         elif self.partype == "subset":
@@ -341,7 +342,7 @@ class Parameters:
             are time, bbox OR Boundingshape, format, projection, projection_parameters, and Coverage.
 
             Keyword argument inputs for 'CMR' may include: dataset, version, start, end, extent_type, spatial_extent
-            Keyword argument inputs for 'required' may include: page_size, page_num, request_mode, include_meta
+            Keyword argument inputs for 'required' may include: page_size, page_num, request_mode, include_meta, client_string
             Keyword argument inputs for 'subset' may include: geom_filepath, start, end, extent_type, spatial_extent
 
         """
@@ -352,7 +353,7 @@ class Parameters:
             self._check_valid_keys()
 
         if self.partype == "required":
-            if self.check_req_values == True and kwargs == {}:
+            if self.check_req_values() and kwargs == {}:
                 pass
             else:
                 reqkeys = self.poss_keys[self._reqtype]
@@ -361,6 +362,7 @@ class Parameters:
                     "page_num": 1,
                     "request_mode": "async",
                     "include_meta": "Y",
+                    "client_string": "icepyx"
                 }
                 for key in reqkeys:
                     if key in kwargs:

--- a/icepyx/core/Earthdata.py
+++ b/icepyx/core/Earthdata.py
@@ -66,7 +66,7 @@ class Earthdata:
 
         response = None
         response = requests.post(
-            token_api_url, json=data, headers={"Accept": "application/json"}
+            token_api_url, json=data, headers={"Accept": "application/json", "Client-Id": "icepyx"}
         )
 
         # check for a valid login

--- a/icepyx/core/granules.py
+++ b/icepyx/core/granules.py
@@ -148,7 +148,7 @@ class Granules:
 
         granule_search_url = "https://cmr.earthdata.nasa.gov/search/granules"
 
-        headers = {"Accept": "application/json"}
+        headers = {"Accept": "application/json", "Client-Id": "icepyx"}
         # DevGoal: check the below request/response for errors and show them if they're there; then gather the results
         # note we should also do this whenever we ping NSIDC-API - make a function to check for errors
         while True:

--- a/icepyx/core/query.py
+++ b/icepyx/core/query.py
@@ -373,7 +373,7 @@ class Query:
         Earthdata Login password:  ········
         >>> reg_a.order_granules()
         >>> reg_a.reqparams
-        {'page_size': 10, 'page_num': 1, 'request_mode': 'async', 'include_meta': 'Y'}
+        {'page_size': 10, 'page_num': 1, 'request_mode': 'async', 'include_meta': 'Y', 'client_string': 'icepyx'}
         """
 
         if not hasattr(self, "_reqparams"):


### PR DESCRIPTION
Adds 'Client-Id' header to CMR requests and 'client_string' to EGI requests to enable metrics collection upstream for those APIs. I am happy to relay those metrics from NSIDC as desired.

Issue #165 