### PR TITLE
Setup Github Action for publishing to PyPI and TestPyPI

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -9,10 +9,8 @@ on:
   push:
     branches:
       - development
-  # Runs for pull requests should be disabled other than for testing purposes
-  pull_request:
-    branches:
-      - development
+  # Trigger manually at https://github.com/icesat2py/icepyx/actions/workflows/publish_to_pypi.yml
+  workflow_dispatch:
 
 jobs:
   publish-pypi:

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -1,0 +1,64 @@
+# Publish archives to PyPI and TestPyPI using GitHub Actions
+name: Publish to PyPI
+
+# Only run for tagged releases and pushes to the development branch
+on:
+  release:
+    types:
+      - published
+  push:
+    branches:
+      - development
+  # Runs for pull requests should be disabled other than for testing purposes
+  pull_request:
+    branches:
+      - development
+
+jobs:
+  publish-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    if: github.repository == 'icesat2py/icepyx'
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2.3.4
+      with:
+        # fetch all history so that setuptools-scm works
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v2.2.1
+      with:
+        python-version: 3.9
+
+    - name: Install dependencies
+      run: python -m pip install setuptools wheel
+
+    # This step is only necessary for testing purposes and for TestPyPI
+    - name: Fix up version string for TestPyPI
+      if: ${{ !startsWith(github.ref, 'refs/tags') }}
+      run: |
+        # Change setuptools-scm local_scheme to "no-local-version" so the
+        # local part of the version isn't included, making the version string
+        # compatible with PyPI.
+        sed --in-place "s/node-and-date/no-local-version/g" setup.py
+
+    - name: Build source and wheel distributions
+      run: |
+        python setup.py sdist bdist_wheel
+        echo ""
+        echo "Generated files:"
+        ls -lh dist/
+
+    - name: Publish to Test PyPI
+      uses: pypa/gh-action-pypi-publish@v1.4.2
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+
+    - name: Publish to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@v1.4.2
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,24 +21,3 @@ jobs:
     #   script:
     #     - export NSIDC_LOGIN=$NSIDC_LOGIN
     #     - pytest icepyx/tests/behind_NSIDC_API_login.py
-
-deploy:
-  - provider: pypi
-    server: https://test.pypi.org/legacy/ 
-    username: "__token__"
-    password: $test_PyPI_API_Token
-    on:
-      branch: development
-      if: commit_message =~ test_pypi
-    skip_existing: true
-    distributions: "sdist bdist_wheel"
-
-# NOTE: the API token on Travis must be set to ALL branches, because a tag build is not considered to be on the master branch: https://travis-ci.community/t/pypi-upload-with-api-token-not-working/5338/5
-  - provider: pypi
-    username: "__token__"
-    password: $PyPI_API_Token
-    on:
-      branch: master
-      tags: true
-    skip_existing: true
-    distributions: "sdist bdist_wheel"

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,10 @@ setuptools.setup(
         "Development Status :: 1 - Planning",
     ],
     use_scm_version={
+        "fallback_version": "unknown",
+        "local_scheme": "node-and-date",
         "write_to": "_version.py",
         "write_to_template": 'version = "{version}"\n',
     },
-    setup_requires=["setuptools>=30.3.0", "wheel", "setuptools_scm"]
+    setup_requires=["setuptools>=30.3.0", "wheel", "setuptools_scm"],
 )


### PR DESCRIPTION
Publishing the icepyx package to PyPI on every tagged (published) release. Every push to the development branch is also published to TestPyPI for testing purposes. Addresses https://github.com/icesat2py/icepyx/issues/170#issuecomment-786299408.

Based on https://github.com/GenericMappingTools/pygmt/pull/679 (and subsequent battleproofed patches).

References:
- https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
- https://github.com/pypa/gh-action-pypi-publish/tree/v1.4.2#usage
- https://pypi.org/project/icepyx/#history
- https://test.pypi.org/project/icepyx/#history

P.S. @JessicaS11, could you please set some secrets at https://github.com/icesat2py/icepyx/settings/secrets/actions called `PYPI_API_TOKEN` and `TEST_PYPI_API_TOKEN` following https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#saving-credentials-on-github? Ping me when you'll done and I'll test that uploading to TestPyPI works. Happy to get added on TestPyPI/PyPI too if it helps.