### PR TITLE
Add quick instructions for installing icepyx via conda

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ package manager.
 
     conda install icepyx
 
- Alternatively, you can also install icepyx using `pip <https://pip.pypa.io/en/stable/>`__.
+Alternatively, you can also install icepyx using `pip <https://pip.pypa.io/en/stable/>`__.
 
     pip install icepyx
 

--- a/README.rst
+++ b/README.rst
@@ -33,40 +33,19 @@ This project combines and generalizes these scripts into a unified framework, ma
 
 Installation
 ------------
-The simplest way to install icepyx is using pip.
 
-.. code-block::
+The simplest way to install icepyx is by using the
+`conda <https://docs.conda.io/projects/conda/en/latest/user-guide/index.html>`__
+package manager.
 
-  pip install icepyx
+    conda install icepyx
 
+ Alternatively, you can also install icepyx using `pip <https://pip.pypa.io/en/stable/>`__.
 
-Windows users will need to first install `Fiona`_, please look at the instructions there. Windows users may consider installing Fiona using pipwin
+    pip install icepyx
 
-.. code-block::
-
-  pip install pipwin
-  pipwin install Fiona 
-
-
-Currently, updated packages are not automatically generated with each build. This means it is possible that pip will not install the latest release of icepyx. In this case, icepyx is also available for use via the GitHub repository. The contents of the repository can be download as a `zipped file`_ or cloned.
-
-To use icepyx this way, fork this repo to your own account, then git clone the repo onto your system. 
-To clone the repository:
-
-.. code-block::
-
-  git clone https://github.com/icesat2py/icepyx.git
-
-
-Provided the location of the repo is part of your $PYTHONPATH, you should simply be able to add import icepyx to your Python document.
-Alternatively, in a command line or terminal, navigate to the folder in your cloned repository containing setup.py and run
-
-.. code-block::
-
-  pip install -e .
-
-
-Future developments of icepyx may include conda as another simplified installation option.
+More detailed instructions for installing `icepyx` can be found at
+https://icepyx.readthedocs.io/en/latest/getting_started/install.html
 
 
 Examples (Jupyter Notebooks)

--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -18,13 +18,9 @@ The simplest way to install IcePyx is by using the
 package manager. The command below takes care of setting up a virtual
 environment, and installs IcePyx along with all the necessary dependencies::
 
-.. code-block::
-
     conda create --name icepyx-env --channel conda-forge icepyx
 
 To activate the virtual environment, you can do::
-
-.. code-block::
 
     conda activate icepyx-env
 

--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -13,10 +13,10 @@ Installation
 Quickstart
 ----------
 
-The simplest way to install IcePyx is by using the
+The simplest way to install icepyx is by using the
 `conda <https://docs.conda.io/projects/conda/en/latest/user-guide/index.html>`__
 package manager. The command below takes care of setting up a virtual
-environment, and installs IcePyx along with all the necessary dependencies::
+environment and installs icepyx along with all the necessary dependencies::
 
     conda create --name icepyx-env --channel conda-forge icepyx
 
@@ -29,21 +29,21 @@ Using conda
 -----------
 
 If you already have a virtual conda environment set up and activated, you can
-install the latest stable release of IcePyx from
+install the latest stable release of icepyx from
 `conda-forge <https://anaconda.org/conda-forge/icepyx>`__ like so::
 
     conda install icepyx
 
-To upgrade an installed version of IcePyx to the latest stable release, do::
+To upgrade an installed version of icepyx to the latest stable release, do::
 
-    conda update pygmt
+    conda update icepyx
 
 
 
 Using pip
 ---------
 
-Alternatively, you can also install IcePyx using `pip <https://pip.pypa.io/en/stable/>`__.
+Alternatively, you can also install icepyx using `pip <https://pip.pypa.io/en/stable/>`__.
 
 .. code-block::
 
@@ -59,10 +59,10 @@ Windows users may consider installing Fiona using pipwin
   pipwin install Fiona
 
 
-Currently, updated packages are not automatically generated with each build.
-This means it is possible that pip will not install the latest release of icepyx.
+Currently, conda and pip packages are generated with each tagged release.
+This means it is possible that these methods will not install the latest merged features of icepyx.
 In this case, icepyx is also available for use via the GitHub repository.
-The contents of the repository can be download as a `zipped file`_ or cloned.
+The contents of the repository can be downloaded as a `zipped file`_ or cloned.
 
 To use icepyx this way, fork this repo to your own account, then git clone the repo onto your system.
 To clone the repository:
@@ -72,9 +72,9 @@ To clone the repository:
   git clone https://github.com/icesat2py/icepyx.git
 
 
-Provided the location of the repo is part of your $PYTHONPATH, you should simply be able to add import icepyx to your Python document.
+Provided the location of the repo is part of your $PYTHONPATH, you should simply be able to add `import icepyx` to your Python document.
 Alternatively, in a command line or terminal, navigate to the folder in your cloned repository containing setup.py and run
 
 .. code-block::
 
-  pip install -e
+  pip install -e.

--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -77,4 +77,4 @@ Alternatively, in a command line or terminal, navigate to the folder in your clo
 
 .. code-block::
 
-  pip install -e .
+  pip install -e.

--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -10,24 +10,65 @@
 Installation
 ============
 
-The simplest way to install icepyx is using pip.
+Quickstart
+----------
+
+The simplest way to install IcePyx is by using the
+`conda <https://docs.conda.io/projects/conda/en/latest/user-guide/index.html>`__
+package manager. The command below takes care of setting up a virtual
+environment, and installs IcePyx along with all the necessary dependencies::
+
+.. code-block::
+
+    conda create --name icepyx-env --channel conda-forge icepyx
+
+To activate the virtual environment, you can do::
+
+.. code-block::
+
+    conda activate icepyx-env
+
+
+Using conda
+-----------
+
+If you already have a virtual conda environment set up and activated, you can
+install the latest stable release of IcePyx from
+`conda-forge <https://anaconda.org/conda-forge/icepyx>`__ like so::
+
+    conda install icepyx
+
+To upgrade an installed version of IcePyx to the latest stable release, do::
+
+    conda update pygmt
+
+
+
+Using pip
+---------
+
+Alternatively, you can also install IcePyx using pip.
 
 .. code-block::
 
   pip install icepyx
 
 
-Windows users will need to first install `Fiona`_, please look at the instructions there. Windows users may consider installing Fiona using pipwin
+Windows users will need to first install `Fiona`_, please look at the instructions there.
+Windows users may consider installing Fiona using pipwin
 
 .. code-block::
 
   pip install pipwin
-  pipwin install Fiona 
+  pipwin install Fiona
 
 
-Currently, updated packages are not automatically generated with each build. This means it is possible that pip will not install the latest release of icepyx. In this case, icepyx is also available for use via the GitHub repository. The contents of the repository can be download as a `zipped file`_ or cloned.
+Currently, updated packages are not automatically generated with each build.
+This means it is possible that pip will not install the latest release of icepyx.
+In this case, icepyx is also available for use via the GitHub repository.
+The contents of the repository can be download as a `zipped file`_ or cloned.
 
-To use icepyx this way, fork this repo to your own account, then git clone the repo onto your system. 
+To use icepyx this way, fork this repo to your own account, then git clone the repo onto your system.
 To clone the repository:
 
 .. code-block::
@@ -41,6 +82,3 @@ Alternatively, in a command line or terminal, navigate to the folder in your clo
 .. code-block::
 
   pip install -e
-
-
-Future developments of icepyx may include conda as another simplified installation option.

--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -43,7 +43,7 @@ To upgrade an installed version of IcePyx to the latest stable release, do::
 Using pip
 ---------
 
-Alternatively, you can also install IcePyx using pip.
+Alternatively, you can also install IcePyx using `pip <https://pip.pypa.io/en/stable/>`__.
 
 .. code-block::
 

--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -77,4 +77,4 @@ Alternatively, in a command line or terminal, navigate to the folder in your clo
 
 .. code-block::
 
-  pip install -e.
+  pip install -e .


### PR DESCRIPTION
Adding 'Quickstart' and 'Using conda' subsections to the installation page so that users know how to install icepyx with the conda package manager. Also did some line wrapping of the 'Using pip' subsection and removed some whitespace.

Preview at https://icepyx--187.org.readthedocs.build/en/187/getting_started/install.html

Partially addresses #185.