### PR TITLE
Add geoviews as extra optional dependency in setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,22 @@
 language: python
 
+before_install:
+  - sudo apt-get update
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  # Useful for debugging any issues with conda
+  - conda info -a
+
 install:
+  - conda create --name icepyx-env --channel conda-forge python=$TRAVIS_PYTHON_VERSION proj
+  - source activate icepyx-env
+
   - pip install -r requirements.txt -r requirements-dev.txt
-  - pip install -e .
+  - pip install -e .[complete]
 
 stages:
   - name: basic tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - conda info -a
 
 install:
-  - conda create --name icepyx-env --channel conda-forge python=$TRAVIS_PYTHON_VERSION proj=7.2.0
+  - conda create --name icepyx-env --channel conda-forge python=$TRAVIS_PYTHON_VERSION proj=7.2.0 geos
   - source activate icepyx-env
 
   - pip install -r requirements.txt -r requirements-dev.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - conda info -a
 
 install:
-  - conda create --name icepyx-env --channel conda-forge python=$TRAVIS_PYTHON_VERSION proj
+  - conda create --name icepyx-env --channel conda-forge python=$TRAVIS_PYTHON_VERSION proj=7.2.0
   - source activate icepyx-env
 
   - pip install -r requirements.txt -r requirements-dev.txt

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.rst", "r") as f:
 with open("requirements.txt") as f:
     INSTALL_REQUIRES = f.read().strip().split("\n")
 
-EXTRAS_REQUIRE = {"viz": ["geoviews >= 1.9.0"]}
+EXTRAS_REQUIRE = {"viz": ["geoviews >= 1.9.0", "cartopy >= 0.18.0"]}
 EXTRAS_REQUIRE["complete"] = sorted(set(sum(EXTRAS_REQUIRE.values(), [])))
 
 setuptools.setup(

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.rst", "r") as f:
 with open("requirements.txt") as f:
     INSTALL_REQUIRES = f.read().strip().split("\n")
 
-EXTRAS_REQUIRE = {"viz": ["geoviews >= 1.9.0", "cartopy >= 0.18.0"]}
+EXTRAS_REQUIRE = {"viz": ["geoviews >= 1.9.0", "cartopy >= 0.18.0", "scipy"]}
 EXTRAS_REQUIRE["complete"] = sorted(set(sum(EXTRAS_REQUIRE.values(), [])))
 
 setuptools.setup(

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,9 @@ with open("README.rst", "r") as f:
 with open("requirements.txt") as f:
     INSTALL_REQUIRES = f.read().strip().split("\n")
 
+EXTRAS_REQUIRE = {"viz": ["geoviews >= 1.9.0"]}
+EXTRAS_REQUIRE["complete"] = sorted(set(sum(EXTRAS_REQUIRE.values(), [])))
+
 setuptools.setup(
     name="icepyx",
     author="The icepyx Developers",
@@ -19,6 +22,7 @@ setuptools.setup(
     license="BSD 3-Clause",
     packages=setuptools.find_packages(exclude=["*tests"]),
     install_requires=INSTALL_REQUIRES,
+    extras_require=EXTRAS_REQUIRE,
     python_requires=">=3",
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
List [`geoviews`](https://geoviews.org) as an optional dependency in the [setup.py](https://github.com/icesat2py/icepyx/blob/development/setup.py) file. Also set up travis to install [PROJ](https://proj.org) and [GEOS](https://trac.osgeo.org/geos) first so that [`cartopy`](https://scitools.org.uk/cartopy/docs/v0.18/) (a requirement of `geoviews`) can be installed.

```
conda create -n icepyx-env -c conda-forge geos pip proj=7.2.0
conda activate icepyx-env
pip install -e .       # install required dependencies first 
pip install -e .[viz]  # install optional dependencies later
```

Note that PROJ version is pinned to 7.2.0 because PROJ 8.0.0 doesn't seem to be supported by cartopy yet, wait for https://github.com/SciTools/cartopy/pull/1752.

Fixes #177.

References:
- https://setuptools.readthedocs.io/en/latest/userguide/dependency_management.html#optional-dependencies
- https://laszukdawid.com/2017/06/04/installing-cartopy-on-ubuntu-14-04-or-travis-ci/