### PR TITLE
surface NSIDC order and http download errors more effectively to user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,7 @@ venv.bak/
 
 # downloaded data
 /download/
+/examples/download
 
 # directory files
 .DS_Store

--- a/icepyx/core/exceptions.py
+++ b/icepyx/core/exceptions.py
@@ -1,0 +1,18 @@
+class QueryError(Exception):
+    """
+    Base class for Query object exceptions
+    """
+    pass
+
+class NsidcQueryError(QueryError):
+    """
+    Raised when an error was returned from NSIDC during the query step."
+    """
+
+    def __init__(self, errmsg, msgtxt = "An error was returned from NSIDC in regards to your query"):
+        self.errmsg = errmsg
+        self.msgtxt = msgtxt
+        super().__init__(self.msgtxt)
+    
+    def __str__(self):
+        return f'{self.msgtxt}: {self.errmsg}'

--- a/icepyx/core/granules.py
+++ b/icepyx/core/granules.py
@@ -50,8 +50,10 @@ def gran_IDs(grans, ids=True, cycles=False, tracks=False):
     """
     assert len(grans) > 0, "Your data object has no granules associated with it"
     # regular expression for extracting parameters from file names
-    rx = re.compile(r'(ATL\d{2})(-\d{2})?_(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})'
-           r'(\d{2})_(\d{4})(\d{2})(\d{2})_(\d{3})_(\d{2})(.*?).(.*?)$')
+    rx = re.compile(
+        r"(ATL\d{2})(-\d{2})?_(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})"
+        r"(\d{2})_(\d{4})(\d{2})(\d{2})_(\d{3})_(\d{2})(.*?).(.*?)$"
+    )
     gran_ids = []
     gran_cycles = []
     gran_tracks = []
@@ -100,6 +102,7 @@ def gran_IDs(grans, ids=True, cycles=False, tracks=False):
         gran_list.append(gran_tracks)
     # return the list of granule parameters
     return gran_list
+
 
 # DevGoal: this will be a great way/place to manage data from the local file system
 # where the user already has downloaded data!
@@ -171,18 +174,20 @@ class Granules:
                 CMRparams, {k: reqparams[k] for k in ("page_size", "page_num")}
             )
             response = requests.get(
-                granule_search_url,
-                headers=headers,
-                params=apifmt.to_string(params),
+                granule_search_url, headers=headers, params=apifmt.to_string(params),
             )
 
             results = json.loads(response.content)
-            
+
             try:
                 response.raise_for_status()
             except requests.HTTPError as e:
-                if b'errors' in response.content:  # If CMR returns a bad status with extra information, display that
-                    raise icepyx.core.exceptions.NsidcQueryError(str(results["errors"])) # exception chaining will display original exception too 
+                if (
+                    b"errors" in response.content
+                ):  # If CMR returns a bad status with extra information, display that
+                    raise icepyx.core.exceptions.NsidcQueryError(
+                        str(results["errors"])
+                    )  # exception chaining will display original exception too
                 else:  # If no 'errors' key, just reraise original exception
                     raise
 
@@ -318,7 +323,10 @@ class Granules:
             esir_root = ET.fromstring(request.content)
             if verbose is True:
                 print("Order request URL: ", requests.utils.unquote(request.url))
-                print("Order request response XML content: ", request.content.decode('utf-8'))
+                print(
+                    "Order request response XML content: ",
+                    request.content.decode("utf-8"),
+                )
 
             # Look up order ID
             orderlist = []
@@ -489,7 +497,7 @@ class Granules:
             if verbose is True:
                 print("Zip download URL: ", downloadURL)
             print("Beginning download of zipped output...")
-            
+
             try:
                 zip_response = session.get(downloadURL)
                 # Raise bad request: Loop will stop for bad response code.
@@ -503,9 +511,8 @@ class Granules:
                 )
             except requests.HTTPError:
                 print(
-                    "Unable to download ",
-                    order,
-                    ". Check granule order for messages.")
+                    "Unable to download ", order, ". Check granule order for messages."
+                )
             # DevGoal: move this option back out to the is2class level and implement it in an alternate way?
             #         #Note: extract the dataset to save it locally
             else:

--- a/icepyx/core/granules.py
+++ b/icepyx/core/granules.py
@@ -10,6 +10,7 @@ from xml.etree import ElementTree as ET
 import zipfile
 
 import icepyx.core.APIformatting as apifmt
+import icepyx.core.exceptions
 
 
 def info(grans):
@@ -186,9 +187,8 @@ class Granules:
                     break
             except KeyError:
                 if "errors" in results.keys():
-                    raise RuntimeError(
-                        "An error was returned from NSIDC in regards to your query: \n"
-                        + str(results["errors"])
+                    raise QueryError.NsidcQueryError(
+                        str(results["errors"])
                     )
 
             # Collect results and increment page_num

--- a/icepyx/core/granules.py
+++ b/icepyx/core/granules.py
@@ -184,10 +184,10 @@ class Granules:
                     b"errors" in response.content
                 ):  # If CMR returns a bad status with extra information, display that
                     raise icepyx.core.exceptions.NsidcQueryError(
-                        e
+                        response.json()["errors"]
                     )  # exception chaining will display original exception too
                 else:  # If no 'errors' key, just reraise original exception
-                    raise
+                    raise e
 
             results = json.loads(response.content)
             if not results["feed"]["entry"]:

--- a/icepyx/core/granules.py
+++ b/icepyx/core/granules.py
@@ -177,8 +177,6 @@ class Granules:
                 granule_search_url, headers=headers, params=apifmt.to_string(params),
             )
 
-            results = json.loads(response.content)
-
             try:
                 response.raise_for_status()
             except requests.HTTPError as e:
@@ -186,11 +184,12 @@ class Granules:
                     b"errors" in response.content
                 ):  # If CMR returns a bad status with extra information, display that
                     raise icepyx.core.exceptions.NsidcQueryError(
-                        str(results["errors"])
+                        e
                     )  # exception chaining will display original exception too
                 else:  # If no 'errors' key, just reraise original exception
                     raise
 
+            results = json.loads(response.content)
             if not results["feed"]["entry"]:
                 # Out of results, so break out of loop
                 break

--- a/icepyx/core/granules.py
+++ b/icepyx/core/granules.py
@@ -181,12 +181,12 @@ class Granules:
             # print(results)
 
             try:
-                if len(results["feed"]["entry"]) == 0:
+                if not results["feed"]["entry"]:
                     # Out of results, so break out of loop
                     break
             except KeyError:
                 if "errors" in results.keys():
-                    raise ValueError(
+                    raise RuntimeError(
                         "An error was returned from NSIDC in regards to your query: \n"
                         + str(results["errors"])
                     )
@@ -502,17 +502,14 @@ class Granules:
                     len(self.orderIDs[i_order:]),
                     " order(s) is downloaded.",
                 )
-                success = True
             except requests.HTTPError:
                 print(
                     "Unable to download ",
                     order,
                     ". Check granule order for messages.")
-                success = False
-
             # DevGoal: move this option back out to the is2class level and implement it in an alternate way?
             #         #Note: extract the dataset to save it locally
-            if success is True:
+            else:
                 with zipfile.ZipFile(io.BytesIO(zip_response.content)) as z:
                     for zfile in z.filelist:
                         # Remove the subfolder name from the filepath

--- a/icepyx/core/granules.py
+++ b/icepyx/core/granules.py
@@ -100,7 +100,6 @@ def gran_IDs(grans, ids=True, cycles=False, tracks=False):
     # return the list of granule parameters
     return gran_list
 
-
 # DevGoal: this will be a great way/place to manage data from the local file system
 # where the user already has downloaded data!
 # DevNote: currently this class is not tested
@@ -401,7 +400,6 @@ class Granules:
                 self.orderIDs.append(orderID)
             else:
                 print("Request failed.")
-            
 
             # DevGoal: save orderIDs more frequently than just at the end for large orders (e.g. for len(reqparams['page_num']) > 5 or 10 or something)
             # Save orderIDs to file to avoid resubmitting order in case kernel breaks down.

--- a/icepyx/core/granules.py
+++ b/icepyx/core/granules.py
@@ -49,8 +49,10 @@ def gran_IDs(grans, ids=True, cycles=False, tracks=False):
     """
     assert len(grans) > 0, "Your data object has no granules associated with it"
     # regular expression for extracting parameters from file names
-    rx = re.compile('(ATL\d{2})(-\d{2})?_(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})'
-           '(\d{2})_(\d{4})(\d{2})(\d{2})_(\d{3})_(\d{2})(.*?).(.*?)$')
+    rx = re.compile(
+        "(ATL\d{2})(-\d{2})?_(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})"
+        "(\d{2})_(\d{4})(\d{2})(\d{2})_(\d{3})_(\d{2})(.*?).(.*?)$"
+    )
     gran_ids = []
     gran_cycles = []
     gran_tracks = []
@@ -67,8 +69,23 @@ def gran_IDs(grans, ids=True, cycles=False, tracks=False):
         # VERS: Product Version
         # AUX: Auxiliary flags
         # SFX: Suffix (h5)
-        PRD,HEM,YY,MM,DD,HH,MN,SS,TRK,CYCL,GRAN,RL,VERS,AUX,SFX = \
-            rx.findall(producer_granule_id).pop()
+        (
+            PRD,
+            HEM,
+            YY,
+            MM,
+            DD,
+            HH,
+            MN,
+            SS,
+            TRK,
+            CYCL,
+            GRAN,
+            RL,
+            VERS,
+            AUX,
+            SFX,
+        ) = rx.findall(producer_granule_id).pop()
         gran_cycles.append(CYCL)
         gran_tracks.append(TRK)
     # list of granule parameters
@@ -84,6 +101,7 @@ def gran_IDs(grans, ids=True, cycles=False, tracks=False):
         gran_list.append(gran_tracks)
     # return the list of granule parameters
     return gran_list
+
 
 # DevGoal: this will be a great way/place to manage data from the local file system
 # where the user already has downloaded data!
@@ -164,9 +182,16 @@ class Granules:
 
             # print(results)
 
-            if len(results["feed"]["entry"]) == 0:
-                # Out of results, so break out of loop
-                break
+            try:
+                if len(results["feed"]["entry"]) == 0:
+                    # Out of results, so break out of loop
+                    break
+            except KeyError:
+                if "errors" in results.keys():
+                    raise ValueError(
+                        "An error was returned from NSIDC in regards to your query: \n"
+                        + str(results["errors"])
+                    )
 
             # Collect results and increment page_num
             self.avail.extend(results["feed"]["entry"])

--- a/icepyx/tests/test_granules.py
+++ b/icepyx/tests/test_granules.py
@@ -603,3 +603,9 @@ def test_correct_granule_list_returned():
         "ATL06_20190226005526_09100205_003_01.h5",
     ]
     assert set(obs_grans) == set(exp_grans)
+
+# def test_avail_granule_CMR_error():
+#     # an example of a "bad input"
+#     response = requests.get("https://cmr.earthdata.nasa.gov/search/granules.json?version=003&temporal=badinput&short_name=ATL08")
+#     # expect it to return an NsidcQueryError
+#     # need to set up a mock to do this test

--- a/icepyx/tests/test_granules.py
+++ b/icepyx/tests/test_granules.py
@@ -621,7 +621,7 @@ def test_avail_granule_CMR_error():
     )
 
     ermsg = "An error was returned from NSIDC in regards to your query: temporal start datetime is invalid: [badinput] is not a valid datetime."
-    with pytest.raises(NsidcQueryError, match=ermsg):
+    with pytest.raises(NsidcQueryError, match=re.escape(ermsg)):
         CMRparams = {"version": "003", "temporal": "badinput", "short_name": "ATL08"}
         reqparams = {"page_size": 1, "page_num": 1}
         Granules().get_avail(CMRparams=CMRparams, reqparams=reqparams)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ pre-commit
 pypistats
 pytest>=4.6
 pytest-cov
+responses


### PR DESCRIPTION
A few changes in response messages from NSIDC meant that users weren't be alerted when their subset orders did not contain any data in the region of interest (this used to return an error message).

May close #79.