### PR TITLE
preliminary AWS access

### DIFF
--- a/examples/ICESat-2_cloud_data_access_example.ipynb
+++ b/examples/ICESat-2_cloud_data_access_example.ipynb
@@ -1,0 +1,197 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## ICESat-2 AWS cloud data access with icepyx\n",
+    "### Utilizing icepyx capabilities to enable cloud data access\n",
+    "This notebook illustrates the use of icepyx for access ICESat-2 data currently available through the AWS (Amazon Web Services) us-west2 hub s3 data bucket.\n",
+    "\n",
+    "## Critical Caveats\n",
+    "***Please do not contact us saying this does not work until you have read this section in detail***\n",
+    "1. ICESat-2 data is not currently publicly available on the cloud (and will not likely be until at least the end of 2021). A limited subset is currently available in an s3 bucket to developers and beta testers who have been registered with NSIDC.\n",
+    "2. This example and the code it describes are part of ongoing development. Current limitations to using these features are described throughout the example, as appropriate.\n",
+    "3. You **MUST** be working within an AWS instance. Otherwise, you will get a permissions error.\n",
+    "\n",
+    "#### Credits\n",
+    "* notebook by: Jessica Scheick\n",
+    "* source material: [is2-nsidc-cloud.py](https://gist.github.com/bradlipovsky/80ab6a7aff3d3524b9616a9fc176065e#file-is2-nsidc-cloud-py-L28) by Brad Lipovsky"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %load_ext autoreload\n",
+    "import icepyx as ipx\n",
+    "# %autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create an icepyx Query object\n",
+    "In order to develop and test cloud data access functionality, here we search for an arbitrary granule over Greenland that was previously determined to be available on s3 using [Earthdata Search](https://search.earthdata.nasa.gov/). s3 availability is not yet included in CMR metadata, so it cannot be determined programmatically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# bounding box\n",
+    "# \"producerGranuleId\": \"ATL03_20191130221008_09930503_004_01.h5\",\n",
+    "short_name = 'ATL03'\n",
+    "spatial_extent = [-45, 58, -35, 75]\n",
+    "date_range = ['2019-11-30','2019-11-30']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reg=ipx.Query(short_name, spatial_extent, date_range)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Construct the granule s3 urls\n",
+    "Since cloud data available is not yet included as part of the standard granule metadata, there is no way for us to check whether or not these s3 bucket urls are valid, since they are constructed from other granule metadata. Thus, you may get FileNotFound Errors when trying to use these urls."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gran_ids = reg.avail_granules(ids=True, s3urls=True)\n",
+    "gran_ids"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Log in to Earthdata and generate an s3 token\n",
+    "You can use icepyx's existing login functionality to generate your s3 data access token, which should be good for five hours. We currently do not have this set up to automatically renew, but if you're interested in adding this functionality please get in touch or submit a PR!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "reg.earthdata_login(\"icepyx_dev\",\"icepyx_dev@gmail.com\", s3token=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "credentials = reg._s3login_credentials"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Set up your s3 access using your credentials"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import s3fs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s3 = s3fs.S3FileSystem(key=credentials['accessKeyId'],\n",
+    "                       secret=credentials['secretAccessKey'],\n",
+    "                       token=credentials['sessionToken'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Select an s3 url and access the data\n",
+    "Development is underway for data read in capabilities, which will include options for cloud data access. Stay tuned and we'd love for you to join us and contribute!\n",
+    "\n",
+    "**Note: If you get a PermissionDenied Error when trying to read in the data, you may not be sending your request from an AWS hub in us-west2. We're currently working on how to alert users if they will not be able to access ICESat-2 data in the cloud for this reason**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s3url = gran_ids[1][0]\n",
+    "# s3url =  's3://nsidc-cumulus-prod-protected/ATLAS/ATL03/004/2019/11/30/ATL03_20191130221008_09930503_004_01.h5'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import h5py\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%time f = h5py.File(s3.open(s3url,'rb'),'r')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/icepyx/core/granules.py
+++ b/icepyx/core/granules.py
@@ -186,7 +186,9 @@ class Granules:
                 CMRparams, {k: reqparams[k] for k in ("page_size", "page_num")}
             )
             response = requests.get(
-                granule_search_url, headers=headers, params=apifmt.to_string(params),
+                granule_search_url,
+                headers=headers,
+                params=apifmt.to_string(params),
             )
 
             try:
@@ -277,7 +279,8 @@ class Granules:
                 "Don't forget to log in to Earthdata using is2_data.earthdata_login(uid, email)"
             )
 
-        base_url = "https://n5eil02u.ecs.nsidc.org/egi/request"
+        # base_url = "https://n5eil02u.ecs.nsidc.org/egi/request"
+        base_url = "https://n5eil01u.ecs.nsidc.org/ATLAS/ATL06.004/"
         # DevGoal: get the base_url from the granules?
 
         self.get_avail(

--- a/icepyx/core/granules.py
+++ b/icepyx/core/granules.py
@@ -34,7 +34,7 @@ def info(grans):
 
 # DevNote: currently this fn is not tested
 # DevNote: could add flag to separate ascending and descending orbits based on ATL03 granule region
-def gran_IDs(grans, ids=True, cycles=False, tracks=False, dates=False):
+def gran_IDs(grans, ids=True, cycles=False, tracks=False, dates=False, s3urls=False):
     """
     Returns a list of granule information for each granule dictionary in the input list of granule dictionaries.
     Granule info may be from a list of those available from NSIDC (for ordering/download)
@@ -51,7 +51,12 @@ def gran_IDs(grans, ids=True, cycles=False, tracks=False, dates=False):
     tracks : boolean, default False
         Return a list of the available Reference Ground Tracks (RGTs) for the granule dictionary
     dates : boolean, default False
-        Return a list of the available dates for the list of granual dictionaries.
+        Return a list of the available dates for the granule dictionary.
+    s3urls : boolean, default False
+        Return a a list of AWS s3 urls for the available granules in the granule dictionary.
+        Note: currently, NSIDC does not provide metadata on which granules are available on s3.
+        Thus, all of the urls may not be valid and may return FileNotFoundErrors
+        s3 data access is currently limited access to beta testers.
     """
     assert len(grans) > 0, "Your data object has no granules associated with it"
     # regular expression for extracting parameters from file names
@@ -63,6 +68,7 @@ def gran_IDs(grans, ids=True, cycles=False, tracks=False, dates=False):
     gran_cycles = []
     gran_tracks = []
     gran_dates = []
+    gran_s3urls = []
     for gran in grans:
         producer_granule_id = gran["producer_granule_id"]
         gran_ids.append(producer_granule_id)
@@ -98,6 +104,9 @@ def gran_IDs(grans, ids=True, cycles=False, tracks=False, dates=False):
         gran_dates.append(
             str(datetime.datetime(year=int(YY), month=int(MM), day=int(DD)).date())
         )
+        gran_s3urls.append(
+            f"s3://nsidc-cumulus-prod-protected/ATLAS/ATL{PRD}/{RL}/{YY}/{MM}/{DD}/{producer_granule_id}"
+        )
     # list of granule parameters
     gran_list = []
     # granule IDs
@@ -112,6 +121,9 @@ def gran_IDs(grans, ids=True, cycles=False, tracks=False, dates=False):
     # granule date
     if dates:
         gran_list.append(gran_dates)
+    # AWS s3 url
+    if s3urls:
+        gran_list.append(gran_s3urls)
     # return the list of granule parameters
     return gran_list
 

--- a/icepyx/core/query.py
+++ b/icepyx/core/query.py
@@ -682,7 +682,7 @@ class Query:
     # ----------------------------------------------------------------------
     # Methods - Login and Granules (NSIDC-API)
 
-    def earthdata_login(self, uid, email):
+    def earthdata_login(self, uid, email, s3token=False):
         """
         Log in to NSIDC EarthData to access data. Generates the needed session and token for most
         data searches and data ordering/download.
@@ -693,6 +693,8 @@ class Query:
             Earthdata login user ID
         email : string
             Email address. NSIDC will automatically send you emails about the status of your order.
+        s3token : boolean, default False
+            Generate AWS s3 ICESat-2 data access credentials
 
         See Also
         --------
@@ -705,12 +707,21 @@ class Query:
         Earthdata Login password:  ········
         """
 
-        capability_url = f"https://n5eil02u.ecs.nsidc.org/egi/capabilities/{self.dataset}.{self._version}.xml"
+        if s3token == False:
+            capability_url = f"https://n5eil02u.ecs.nsidc.org/egi/capabilities/{self.dataset}.{self._version}.xml"
+        elif s3token == True:
+            capability_url = "https://data.nsidc.earthdatacloud.nasa.gov/s3credentials"
         self._session = Earthdata(uid, email, capability_url).login()
+
+        # DevNote: might make sense to do this part elsewhere in the future, but wanted to get it implemented for now
+        if s3token == True:
+            self._s3login_credentials = json.loads(
+                self._session.get(self._session.get(capability_url).url).content
+            )
         self._email = email
 
     # DevGoal: check to make sure the see also bits of the docstrings work properly in RTD
-    def avail_granules(self, ids=False, cycles=False, tracks=False):
+    def avail_granules(self, ids=False, cycles=False, tracks=False, s3urls=False):
         """
         Obtain information about the available granules for the query
         object's parameters. By default, a complete list of available granules is
@@ -727,6 +738,9 @@ class Query:
 
         tracks : boolean, default False
             Indicates whether the function should return a list of RGTs.
+
+        s3urls : boolean, default False
+            Indicates whether the function should return a list of potential AWS s3 urls.
 
         Examples
         --------
@@ -752,10 +766,14 @@ class Query:
         except AttributeError:
             self.granules.get_avail(self.CMRparams, self.reqparams)
 
-        if ids or cycles or tracks:
-            # list of outputs in order of ids, cycles, tracks
+        if ids or cycles or tracks or s3urls:
+            # list of outputs in order of ids, cycles, tracks, s3urls
             return granules.gran_IDs(
-                self.granules.avail, ids=ids, cycles=cycles, tracks=tracks
+                self.granules.avail,
+                ids=ids,
+                cycles=cycles,
+                tracks=tracks,
+                s3urls=s3urls,
             )
         else:
             return granules.info(self.granules.avail)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,10 @@ with open("README.rst", "r") as f:
 with open("requirements.txt") as f:
     INSTALL_REQUIRES = f.read().strip().split("\n")
 
-EXTRAS_REQUIRE = {"viz": ["geoviews >= 1.9.0", "cartopy >= 0.18.0", "scipy"]}
+EXTRAS_REQUIRE = {
+    "viz": ["geoviews >= 1.9.0", "cartopy >= 0.18.0", "scipy"],
+    "cloud": ["s3fs"],
+}
 EXTRAS_REQUIRE["complete"] = sorted(set(sum(EXTRAS_REQUIRE.values(), [])))
 
 setuptools.setup(


### PR DESCRIPTION
There are currently a host of caveats to ICESat-2 cloud data access (including that it is NOT YET PUBLIC and STILL IN DEVELOPMENT), but this is a start towards some of the items that will be needed to enable it:
1. an example notebook with the limitations and what you can do currently
2. usage of a Query object to generate an s3 access token using your Earthdata credentials (assuming your Earthdata user ID will grant you access to the data for beta testing)
3. usage of a granule search (within a query object) to generate s3 urls (with the caveat that these aren't yet included in granule metadata, so there's no way to filter out which urls are actually valid)

Acknowledging these caveats, I think we can move forward with reviewing this PR so that other beta testers can use the functionality, and we can continue improving cloud data access as we go.