### PR TITLE
update docstring test config params

### DIFF
--- a/icepyx/conftest.py
+++ b/icepyx/conftest.py
@@ -1,0 +1,7 @@
+import icepyx
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def add_ipx(doctest_namespace):
+    doctest_namespace["ipx"] = icepyx

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,4 @@ minversion = 2.0
 norecursedirs = .git
 python_files = test*.py
 addopts = --cov=./
+doctest_optionflags = NORMALIZE_WHITESPACE


### PR DESCRIPTION
We're working to update our docstring tests. This PR introduces a pytest fixture (in conftest.py) that enables us to use ipx to access the icepyx module and adds the NORMALIZE_WHITESPACE doctest option universally instead of per-test with `#doctest +NORMALIZE_WHITESPACE` (see https://docs.pytest.org/en/6.2.x/doctest.html#using-doctest-options).

Should be merged before #249.