### PR TITLE
debug behind login Travis CI tests

### DIFF
--- a/icepyx/core/Earthdata.py
+++ b/icepyx/core/Earthdata.py
@@ -129,7 +129,7 @@ class Earthdata:
         try:
             url = "urs.earthdata.nasa.gov"
             self.uid, _, self.pswd = netrc.netrc(self.netrc).authenticators(url)
-            session = self._start_session()
+            self._start_session()
 
         except:
             # if not using an environmental variable for password
@@ -137,7 +137,7 @@ class Earthdata:
                 self.pswd = getpass.getpass("Earthdata Login password: ")
             for i in range(attempts):
                 try:
-                    session = self._start_session()
+                    self._start_session()
                     break
                 except KeyError:
                     pass

--- a/icepyx/tests/conftest.py
+++ b/icepyx/tests/conftest.py
@@ -9,7 +9,7 @@ def mock_settings_env_vars():
         "os.environ",
         {
             "EARTHDATA_USERNAME": "icepyx_devteam",
-            "EARTHDATA_PASSWORD": "EARTHDATA_PASSWORD",
+            "EARTHDATA_PASSWORD": "fake_earthdata_password",
             "EARTHDATA_EMAIL": "icepyx.dev@gmail.com",
         },
     ):

--- a/icepyx/tests/conftest.py
+++ b/icepyx/tests/conftest.py
@@ -5,20 +5,27 @@ from unittest import mock
 # PURPOSE: mock environmental variables
 @pytest.fixture(scope="session", autouse=True)
 def mock_settings_env_vars():
-    with mock.patch.dict("os.environ", {
-        "EARTHDATA_USERNAME": "icepyx_devteam",
-        "EARTHDATA_PASSWORD": os.environ.get("NSIDC_LOGIN"),
-        "EARTHDATA_EMAIL": "icepyx.dev@gmail.com"}):
+    with mock.patch.dict(
+        "os.environ",
+        {
+            "EARTHDATA_USERNAME": "icepyx_devteam",
+            "EARTHDATA_PASSWORD": "EARTHDATA_PASSWORD",
+            "EARTHDATA_EMAIL": "icepyx.dev@gmail.com",
+        },
+    ):
         yield
+
 
 @pytest.fixture(scope="session")
 def username():
-    return os.environ.get('EARTHDATA_USERNAME')
+    return os.environ.get("EARTHDATA_USERNAME")
+
 
 @pytest.fixture(scope="session")
 def password():
-    return os.environ.get('EARTHDATA_PASSWORD')
+    return os.environ.get("EARTHDATA_PASSWORD")
+
 
 @pytest.fixture(scope="session")
 def email():
-    return os.environ.get('EARTHDATA_EMAIL')
+    return os.environ.get("EARTHDATA_EMAIL")

--- a/icepyx/tests/test_behind_NSIDC_API_login.py
+++ b/icepyx/tests/test_behind_NSIDC_API_login.py
@@ -10,8 +10,8 @@ import warnings
 # check that downloaded data is subset? or is this an NSIDC level test so long as we verify the right info is submitted?
 
 
-@pytest.fixture
-def reg(scope="module"):
+@pytest.fixture(scope="module")
+def reg():
     live_reg = ipx.Query(
         "ATL06", [-55, 68, -48, 71], ["2019-02-22", "2019-02-28"], version="004"
     )
@@ -19,8 +19,8 @@ def reg(scope="module"):
     del live_reg
 
 
-@pytest.fixture
-def session(reg, scope="module"):
+@pytest.fixture(scope="module")
+def session(reg):
     capability_url = f"https://n5eil02u.ecs.nsidc.org/egi/capabilities/{reg.product}.{reg._version}.xml"
     ed_obj = Earthdata(
         "icepyx_devteam",

--- a/icepyx/tests/test_behind_NSIDC_API_login.py
+++ b/icepyx/tests/test_behind_NSIDC_API_login.py
@@ -22,14 +22,15 @@ def reg(scope="module"):
 @pytest.fixture
 def session(reg, scope="module"):
     capability_url = f"https://n5eil02u.ecs.nsidc.org/egi/capabilities/{reg.product}.{reg._version}.xml"
-    live_session = Earthdata(
+    ed_obj = Earthdata(
         "icepyx_devteam",
         "icepyx.dev@gmail.com",
         capability_url=capability_url,
         pswd=os.getenv("NSIDC_LOGIN"),
-    )._start_session()
-    yield live_session
-    live_session.close()
+    )
+    ed_obj._start_session()
+    yield ed_obj.session
+    ed_obj.session.close()
 
 
 ########## is2ref module ##########
@@ -41,8 +42,6 @@ def test_get_custom_options_output(session):
     obs = is2ref._get_custom_options(session, "ATL06", "004")
     with open("./icepyx/tests/ATL06v04_options.json") as exp_json:
         exp = json.load(exp_json)
-        print(exp.keys())
-        # print(exp)
         assert all(keys in obs.keys() for keys in exp.keys())
         assert all(obs[key] == exp[key] for key in exp.keys())
 

--- a/icepyx/tests/test_behind_NSIDC_API_login.py
+++ b/icepyx/tests/test_behind_NSIDC_API_login.py
@@ -12,20 +12,24 @@ import warnings
 
 @pytest.fixture
 def reg(scope="module"):
-    return ipx.Query(
+    live_reg = ipx.Query(
         "ATL06", [-55, 68, -48, 71], ["2019-02-22", "2019-02-28"], version="004"
     )
+    yield live_reg
+    del live_reg
 
 
 @pytest.fixture
 def session(reg, scope="module"):
     capability_url = f"https://n5eil02u.ecs.nsidc.org/egi/capabilities/{reg.product}.{reg._version}.xml"
-    return Earthdata(
+    live_session = Earthdata(
         "icepyx_devteam",
         "icepyx.dev@gmail.com",
         capability_url=capability_url,
         pswd=os.getenv("NSIDC_LOGIN"),
     )._start_session()
+    yield live_session
+    live_session.close()
 
 
 ########## is2ref module ##########
@@ -35,7 +39,10 @@ import json
 
 def test_get_custom_options_output(session):
     obs = is2ref._get_custom_options(session, "ATL06", "004")
-    with open("./ATL06v04_options.json", "r") as exp:
+    with open("./icepyx/tests/ATL06v04_options.json") as exp_json:
+        exp = json.load(exp_json)
+        print(exp.keys())
+        # print(exp)
         assert all(keys in obs.keys() for keys in exp.keys())
         assert all(obs[key] == exp[key] for key in exp.keys())
 
@@ -44,8 +51,9 @@ def test_get_custom_options_output(session):
 # NOTE: best this test can do at the moment is a successful download with no errors...
 def test_download_granules_with_subsetting(reg, session):
     path = "./downloads_subset"
-    reg.order_granules(session)
-    reg.download_granules(session, path)
+    reg._session = session
+    reg.order_granules()
+    reg.download_granules(path)
 
 
 # def test_download_granules_without_subsetting(reg_a, session):


### PR DESCRIPTION
Travis CI tests that are behind NSIDC login were failing in all builds due to a lack of successful initiation of an authenticated session. This updates the tests to properly log in and pass.

Closes #286 