### PR TITLE
manually remove 'z' from datetime string

### DIFF
--- a/doc/source/user_guide/documentation/classes_dev_uml.svg
+++ b/doc/source/user_guide/documentation/classes_dev_uml.svg
@@ -18,7 +18,7 @@
 <text text-anchor="start" x="8" y="-196.3" font-family="Times,serif" font-size="14.00">capability_url</text>
 <text text-anchor="start" x="8" y="-181.3" font-family="Times,serif" font-size="14.00">email</text>
 <text text-anchor="start" x="8" y="-166.3" font-family="Times,serif" font-size="14.00">netrc : NoneType</text>
-<text text-anchor="start" x="8" y="-151.3" font-family="Times,serif" font-size="14.00">pswd : str, NoneType</text>
+<text text-anchor="start" x="8" y="-151.3" font-family="Times,serif" font-size="14.00">pswd : NoneType, str</text>
 <text text-anchor="start" x="8" y="-136.3" font-family="Times,serif" font-size="14.00">session : Session</text>
 <text text-anchor="start" x="8" y="-121.3" font-family="Times,serif" font-size="14.00">uid</text>
 <polyline fill="none" stroke="black" points="0,-113.5 301,-113.5 "/>
@@ -163,7 +163,7 @@
 <polygon fill="none" stroke="black" points="1022,-38 1022,-257 1275,-257 1275,-38 1022,-38"/>
 <text text-anchor="middle" x="1148.5" y="-241.8" font-family="Times,serif" font-size="14.00">Parameters</text>
 <polyline fill="none" stroke="black" points="1022,-234 1275,-234 "/>
-<text text-anchor="start" x="1030" y="-218.8" font-family="Times,serif" font-size="14.00">_fmted_keys : dict, NoneType</text>
+<text text-anchor="start" x="1030" y="-218.8" font-family="Times,serif" font-size="14.00">_fmted_keys : NoneType, dict</text>
 <text text-anchor="start" x="1030" y="-203.8" font-family="Times,serif" font-size="14.00">_poss_keys : dict</text>
 <text text-anchor="start" x="1030" y="-188.8" font-family="Times,serif" font-size="14.00">_reqtype : str, NoneType</text>
 <text text-anchor="start" x="1030" y="-173.8" font-family="Times,serif" font-size="14.00">fmted_keys</text>
@@ -249,7 +249,7 @@
 <text text-anchor="start" x="1321" y="-211.3" font-family="Times,serif" font-size="14.00">_version : NoneType</text>
 <text text-anchor="start" x="1321" y="-196.3" font-family="Times,serif" font-size="14.00">path : NoneType</text>
 <text text-anchor="start" x="1321" y="-181.3" font-family="Times,serif" font-size="14.00">product : NoneType</text>
-<text text-anchor="start" x="1321" y="-166.3" font-family="Times,serif" font-size="14.00">wanted : dict, NoneType</text>
+<text text-anchor="start" x="1321" y="-166.3" font-family="Times,serif" font-size="14.00">wanted : NoneType, dict</text>
 <polyline fill="none" stroke="black" points="1313,-158.5 1802,-158.5 "/>
 <text text-anchor="start" x="1321" y="-143.3" font-family="Times,serif" font-size="14.00">__init__(vartype, avail, wanted, session, product, version, path)</text>
 <text text-anchor="start" x="1321" y="-128.3" font-family="Times,serif" font-size="14.00">_check_valid_lists(vgrp, allpaths, var_list, beam_list, keyword_list)</text>

--- a/icepyx/core/read.py
+++ b/icepyx/core/read.py
@@ -363,13 +363,14 @@ class Read:
                 pass
 
             try:
-                # manually remove 'Z' from datetime to allow conversion to np.datetime64 object (support for timezones is deprecated and causes a seg fault)
-                is2ds["data_start_utc"] = np.datetime64(
-                    is2ds.data_start_utc.data[0].astype(str)[:-1]
-                )
-                is2ds["data_end_utc"] = np.datetime64(
-                    is2ds.data_end_utc.data[0].astype(str)[:-1]
-                )
+                if is2ds["data_end_utc"].data[0] == "Z":
+                    # manually remove 'Z' from datetime to allow conversion to np.datetime64 object (support for timezones is deprecated and causes a seg fault)
+                    is2ds["data_start_utc"] = np.datetime64(
+                        is2ds.data_start_utc.data[0].astype(str)[:-1]
+                    )
+                    is2ds["data_end_utc"] = np.datetime64(
+                        is2ds.data_end_utc.data[0].astype(str)[:-1]
+                    )
 
             except AttributeError:
                 pass

--- a/icepyx/core/read.py
+++ b/icepyx/core/read.py
@@ -363,7 +363,10 @@ class Read:
                 pass
 
             try:
-                if is2ds["data_end_utc"].data[0] == "Z":
+                if (
+                    hasattr(is2ds, "data_start_utc")
+                    and is2ds["data_start_utc"].data[0].astype(str)[:-1] == "Z"
+                ):
                     # manually remove 'Z' from datetime to allow conversion to np.datetime64 object (support for timezones is deprecated and causes a seg fault)
                     is2ds["data_start_utc"] = np.datetime64(
                         is2ds.data_start_utc.data[0].astype(str)[:-1]

--- a/icepyx/core/read.py
+++ b/icepyx/core/read.py
@@ -365,7 +365,7 @@ class Read:
             try:
                 if (
                     hasattr(is2ds, "data_start_utc")
-                    and is2ds["data_start_utc"].data[0].astype(str)[:-1] == "Z"
+                    and is2ds["data_start_utc"].data[0].astype(str).endswith("Z")
                 ):
                     # manually remove 'Z' from datetime to allow conversion to np.datetime64 object (support for timezones is deprecated and causes a seg fault)
                     is2ds["data_start_utc"] = np.datetime64(

--- a/icepyx/core/read.py
+++ b/icepyx/core/read.py
@@ -371,6 +371,9 @@ class Read:
                     is2ds["data_end_utc"] = np.datetime64(
                         is2ds.data_end_utc.data[0].astype(str)[:-1]
                     )
+                else:
+                    is2ds["data_start_utc"] = is2ds.data_start_utc.astype(np.datetime64)
+                    is2ds["data_end_utc"] = is2ds.data_end_utc.astype(np.datetime64)
 
             except AttributeError:
                 pass

--- a/icepyx/core/read.py
+++ b/icepyx/core/read.py
@@ -363,13 +363,14 @@ class Read:
                 pass
 
             try:
-                # DevNote: these lines may cause a NumPy Warning, as explained here: https://numpy.org/doc/stable/release/1.11.0-notes.html?
-                # The below line will silence this warning...
-                # warnings.filterwarnings(
-                #     "default", category=DeprecationWarning, module=np.astype()
-                # )
-                is2ds["data_start_utc"] = is2ds.data_start_utc.astype(np.datetime64)
-                is2ds["data_end_utc"] = is2ds.data_end_utc.astype(np.datetime64)
+                # manually remove 'Z' from datetime to allow conversion to np.datetime64 object (support for timezones is deprecated and causes a seg fault)
+                is2ds["data_start_utc"] = np.datetime64(
+                    is2ds.data_start_utc.data[0].astype(str)[:-1]
+                )
+                is2ds["data_end_utc"] = np.datetime64(
+                    is2ds.data_end_utc.data[0].astype(str)[:-1]
+                )
+
             except AttributeError:
                 pass
 


### PR DESCRIPTION
Per the segfault issue noted in #281, Xarray/pandas/numpy no longer automatically handle datetimes brought in with a timezone ('Z' at the end of the datetime string). This provides a fix by checking and manually removing the last character of the datetime string if it's a Z.