### PR TITLE
Support Python 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=["*tests"]),
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRAS_REQUIRE,
-    python_requires=">=3, <3.10",
+    python_requires=">=3, <3.11",
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
Set upper pin of Python to be 3.10. Original pin to <3.10 was set in 93012a4119d514e2aa3b7bb2777908dcaf551da5 (icepyx v0.6.0).