### PR TITLE
update cloud tutorial to work with publicly accessible cloud data

### DIFF
--- a/doc/source/example_notebooks/IS2_cloud_data_access.ipynb
+++ b/doc/source/example_notebooks/IS2_cloud_data_access.ipynb
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,27 +63,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[['ATL03_20191130112041_09860505_005_01.h5',\n",
-       "  'ATL03_20191130112606_09860506_005_01.h5',\n",
-       "  'ATL03_20191130220138_09930502_005_01.h5',\n",
-       "  'ATL03_20191130221008_09930503_005_01.h5'],\n",
-       " ['s3://nsidc-cumulus-prod-protected/ATLAS/ATL03/005/2019/11/30/ATL03_20191130112041_09860505_005_01.h5',\n",
-       "  's3://nsidc-cumulus-prod-protected/ATLAS/ATL03/005/2019/11/30/ATL03_20191130112606_09860506_005_01.h5',\n",
-       "  's3://nsidc-cumulus-prod-protected/ATLAS/ATL03/005/2019/11/30/ATL03_20191130220138_09930502_005_01.h5',\n",
-       "  's3://nsidc-cumulus-prod-protected/ATLAS/ATL03/005/2019/11/30/ATL03_20191130221008_09930503_005_01.h5']]"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "gran_ids = reg.avail_granules(ids=True, cloud=True)\n",
     "gran_ids"
@@ -101,26 +83,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdin",
-     "output_type": "stream",
-     "text": [
-      "Earthdata Login password:  ·········\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "reg.earthdata_login(\"icepyx_devteam\",\"icepyx_dev@gmail.com\", s3token=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -136,7 +110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -145,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,7 +140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -178,7 +152,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -188,18 +162,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 47.3 ms, sys: 9.74 ms, total: 57 ms\n",
-      "Wall time: 324 ms\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%time f = h5py.File(s3.open(s3url,'rb'),'r')"
    ]

--- a/icepyx/core/granules.py
+++ b/icepyx/core/granules.py
@@ -111,9 +111,13 @@ def gran_IDs(grans, ids=True, cycles=False, tracks=False, dates=False, cloud=Fal
                 str(datetime.datetime(year=int(YY), month=int(MM), day=int(DD)).date())
             )
 
-            for link in gran["links"]:
-                if link["href"].startswith("s3") and link["href"].endswith(".h5"):
-                    gran_s3urls.append(link["href"])
+            try:
+                for link in gran["links"]:
+                    if link["href"].startswith("s3") and link["href"].endswith(".h5"):
+                        gran_s3urls.append(link["href"])
+            except KeyError:
+                pass
+
     # list of granule parameters
     gran_list = []
     # granule IDs

--- a/icepyx/core/granules.py
+++ b/icepyx/core/granules.py
@@ -35,7 +35,7 @@ def info(grans):
 
 # DevNote: currently this fn is not tested
 # DevNote: could add flag to separate ascending and descending orbits based on ATL03 granule region
-def gran_IDs(grans, ids=True, cycles=False, tracks=False, dates=False, s3urls=False):
+def gran_IDs(grans, ids=True, cycles=False, tracks=False, dates=False, cloud=False):
     """
     Returns a list of granule information for each granule dictionary in the input list of granule dictionaries.
     Granule info may be from a list of those available from NSIDC (for ordering/download)
@@ -53,7 +53,7 @@ def gran_IDs(grans, ids=True, cycles=False, tracks=False, dates=False, s3urls=Fa
         Return a list of the available Reference Ground Tracks (RGTs) for the granule dictionary
     dates : boolean, default False
         Return a list of the available dates for the granule dictionary.
-    s3urls : boolean, default False
+    cloud : boolean, default False
         Return a a list of AWS s3 urls for the available granules in the granule dictionary.
         Note: currently, NSIDC does not provide metadata on which granules are available on s3.
         Thus, all of the urls may not be valid and may return FileNotFoundErrors.
@@ -76,8 +76,6 @@ def gran_IDs(grans, ids=True, cycles=False, tracks=False, dates=False, s3urls=Fa
 
         if int(gran["producer_granule_id"][3:5]) > 13:
             continue
-            # ultimately use this to get the s3urls from the metadata
-            # gran_s3urls.append(gran["links"][])
 
         else:
             # PRD: ICESat-2 product
@@ -112,9 +110,10 @@ def gran_IDs(grans, ids=True, cycles=False, tracks=False, dates=False, s3urls=Fa
             gran_dates.append(
                 str(datetime.datetime(year=int(YY), month=int(MM), day=int(DD)).date())
             )
-            gran_s3urls.append(
-                f"s3://nsidc-cumulus-prod-protected/ATLAS/{PRD}/{RL}/{YY}/{MM}/{DD}/{producer_granule_id}"
-            )
+
+            for link in gran["links"]:
+                if link["href"].startswith("s3") and link["href"].endswith(".h5"):
+                    gran_s3urls.append(link["href"])
     # list of granule parameters
     gran_list = []
     # granule IDs
@@ -130,12 +129,7 @@ def gran_IDs(grans, ids=True, cycles=False, tracks=False, dates=False, s3urls=Fa
     if dates:
         gran_list.append(gran_dates)
     # AWS s3 url
-    if s3urls:
-        warnings.filterwarnings("always")
-        warnings.warn(
-            "You MUST be pre-authenticated by NSIDC as a beta tester to have cloud access to ICESat-2 data",
-            UserWarning,
-        )
+    if cloud:
         gran_list.append(gran_s3urls)
     # return the list of granule parameters
     return gran_list

--- a/icepyx/core/query.py
+++ b/icepyx/core/query.py
@@ -908,7 +908,7 @@ class Query(GenQuery):
         self._email = email
 
     # DevGoal: check to make sure the see also bits of the docstrings work properly in RTD
-    def avail_granules(self, ids=False, cycles=False, tracks=False, s3urls=False):
+    def avail_granules(self, ids=False, cycles=False, tracks=False, cloud=False):
         """
         Obtain information about the available granules for the query
         object's parameters. By default, a complete list of available granules is
@@ -926,8 +926,10 @@ class Query(GenQuery):
         tracks : boolean, default False
             Indicates whether the function should return a list of RGTs.
 
-        s3urls : boolean, default False
-            Indicates whether the function should return a list of potential AWS s3 urls.
+        cloud : boolean, default False
+            Indicates whether the function should return data available in the cloud.
+            Note: except in rare cases while data is in the process of being appended to,
+            data available in the cloud and for download via on-premesis will be identical.
 
         Examples
         --------
@@ -952,16 +954,16 @@ class Query(GenQuery):
         try:
             self.granules.avail
         except AttributeError:
-            self.granules.get_avail(self.CMRparams, self.reqparams)
+            self.granules.get_avail(self.CMRparams, self.reqparams, cloud=cloud)
 
-        if ids or cycles or tracks or s3urls:
-            # list of outputs in order of ids, cycles, tracks, s3urls
+        if ids or cycles or tracks or cloud:
+            # list of outputs in order of ids, cycles, tracks, cloud
             return granules.gran_IDs(
                 self.granules.avail,
                 ids=ids,
                 cycles=cycles,
                 tracks=tracks,
-                s3urls=s3urls,
+                cloud=cloud,
             )
         else:
             return granules.info(self.granules.avail)


### PR DESCRIPTION
The goal here was to get the data access notebook working in time for the Oct 2022 IS2 Science Team meeting. This PR updates granules to get the s3 urls directly from the CMR metadata rather than constructing them manually, and the CMR metadata are queried specifically for cloud data (which is identical to the on-premises data that you would download from NSIDC). It does not yet address simplifications to the authentication process (planned with the introduction of [earthaccess](https://github.com/nsidc/earthdata/tree/main), currently still packaged as earthdata).

NOTE: this PR will need to be merged after #331, at which point this branch should be selectively rebased to streamline the review).