### PR TITLE
fix login fixture causing planned release tests to fail

### DIFF
--- a/doc/source/user_guide/changelog/v0.7.0.rst
+++ b/doc/source/user_guide/changelog/v0.7.0.rst
@@ -38,8 +38,9 @@ Bug fixes
     - reactivate atl10 and atl12 viz tests and update sizes
     - disable ATL13 viz tests
 
--  manual solution for getting ATL15 s3 urls via icepyx (#413) 
+- manual solution for getting ATL15 s3 urls via icepyx (#413) 
 
+- fix NSIDC login tests (#418)
 
 Deprecations
 ~~~~~~~~~~~~

--- a/icepyx/tests/test_behind_NSIDC_API_login.py
+++ b/icepyx/tests/test_behind_NSIDC_API_login.py
@@ -28,7 +28,7 @@ def session(reg):
         f.write("machine {1} login {0} password {2}\n".format(*args))
         os.chmod(netrc_file, 0o600)
 
-    ed_obj = reg.earthaccess.login()
+    ed_obj = reg.earthdata_login()
     yield ed_obj._session
     ed_obj._session.close()
 


### PR DESCRIPTION
next release (#417) tests failed due incorrect command in tests that use NSIDC login. This fixes the fixture that was causing the test failure.