### PR TITLE
get s3urls for all data products

### DIFF
--- a/icepyx/core/granules.py
+++ b/icepyx/core/granules.py
@@ -55,9 +55,6 @@ def gran_IDs(grans, ids=False, cycles=False, tracks=False, dates=False, cloud=Fa
         Return a list of the available dates for the granule dictionary.
     cloud : boolean, default False
         Return a a list of AWS s3 urls for the available granules in the granule dictionary.
-        Note: currently, NSIDC does not provide metadata on which granules are available on s3.
-        Thus, all of the urls may not be valid and may return FileNotFoundErrors.
-        s3 data access is currently limited access to beta testers.
     """
     assert len(grans) > 0, "Your data object has no granules associated with it"
     # regular expression for extracting parameters from file names

--- a/icepyx/core/granules.py
+++ b/icepyx/core/granules.py
@@ -167,7 +167,7 @@ class Granules:
     # ----------------------------------------------------------------------
     # Methods
 
-    def get_avail(self, CMRparams, reqparams, cloud=True):
+    def get_avail(self, CMRparams, reqparams, cloud=False):
         """
         Get a list of available granules for the query object's parameters.
         Generates the `avail` attribute of the granules object.
@@ -179,8 +179,8 @@ class Granules:
         reqparams : dictionary
             Dictionary of properly formatted parameters required for searching, ordering,
             or downloading from NSIDC.
-        cloud : boolean, default False
-            Whether or not you want data available in the cloud (versus on premises).
+        cloud : deprecated, boolean, default False
+            CMR metadata is always collected for the cloud system.
 
         Notes
         -----
@@ -205,13 +205,10 @@ class Granules:
         headers = {"Accept": "application/json", "Client-Id": "icepyx"}
         # note we should also check for errors whenever we ping NSIDC-API - make a function to check for errors
 
-        if cloud:
-            prov_flag = "NSIDC_CPRD"
-        else:
-            prov_flag = "NSIDC_ECS"
-
         params = apifmt.combine_params(
-            CMRparams, {k: reqparams[k] for k in ["page_size"]}, {"provider": prov_flag}
+            CMRparams,
+            {k: reqparams[k] for k in ["page_size"]},
+            {"provider": "NSIDC_CPRD"},
         )
 
         cmr_search_after = None

--- a/icepyx/core/granules.py
+++ b/icepyx/core/granules.py
@@ -205,7 +205,6 @@ class Granules:
         headers = {"Accept": "application/json", "Client-Id": "icepyx"}
         # note we should also check for errors whenever we ping NSIDC-API - make a function to check for errors
 
-        # do we still need this? actually, this may be where the issue comes in, because if the cloud ones aren't gotten when avail is created...
         if cloud:
             prov_flag = "NSIDC_CPRD"
         else:

--- a/icepyx/core/query.py
+++ b/icepyx/core/query.py
@@ -193,7 +193,7 @@ class Query(GenQuery):
     >>> reg_a_dates = ['2019-02-20','2019-02-28']
     >>> reg_a = Query('ATL06', reg_a_bbox, reg_a_dates)
     >>> print(reg_a)
-    Product ATL06 v005
+    Product ATL06 v006
     ('bounding_box', [-55.0, 68.0, -48.0, 71.0])
     Date range ['2019-02-20', '2019-02-28']
 
@@ -211,7 +211,7 @@ class Query(GenQuery):
     >>> reg_a_dates = ['2019-02-22','2019-02-28']
     >>> reg_a = Query('ATL06', aoi, reg_a_dates)
     >>> print(reg_a)
-    Product ATL06 v005
+    Product ATL06 v006
     ('polygon', [-55.0, 68.0, -55.0, 71.0, -48.0, 71.0, -48.0, 68.0, -55.0, 68.0])
     Date range ['2019-02-22', '2019-02-28']
 
@@ -322,11 +322,11 @@ class Query(GenQuery):
         --------
         >>> reg_a = ipx.Query('ATL06',[-55, 68, -48, 71],['2019-02-20','2019-02-28'])
         >>> reg_a.product_version
-        '005'
+        '006'
 
-        >>> reg_a = ipx.Query('ATL06',[-55, 68, -48, 71],['2019-02-20','2019-02-28'], version='1')
+        >>> reg_a = ipx.Query('ATL06',[-55, 68, -48, 71],['2019-02-20','2019-02-28'], version='4')
         >>> reg_a.product_version
-        '001'
+        '004'
         """
         return self._version
 
@@ -548,7 +548,7 @@ class Query(GenQuery):
         >>> reg_a = ipx.Query('ATL06',[-55, 68, -48, 71],['2019-02-20','2019-02-28'])
         >>> reg_a.CMRparams
         {'short_name': 'ATL06',
-        'version': '005',
+        'version': '006',
         'temporal': '2019-02-20T00:00:00Z,2019-02-28T23:59:59Z',
         'bounding_box': '-55.0,68.0,-48.0,71.0'}
         """
@@ -773,7 +773,7 @@ class Query(GenQuery):
         >>> reg_a.product_summary_info()
         title :  ATLAS/ICESat-2 L3A Land Ice Height V005
         short_name :  ATL06
-        version_id :  005
+        version_id :  006
         time_start :  2018-10-14T00:00:00.000Z
         coordinate_system :  CARTESIAN
         summary :  This data set (ATL06) provides geolocated, land-ice surface heights (above the WGS 84 ellipsoid, ITRF2014 reference frame), plus ancillary parameters that can be used to interpret and assess the quality of the height estimates. The data were acquired by the Advanced Topographic Laser Altimeter System (ATLAS) instrument on board the Ice, Cloud and land Elevation Satellite-2 (ICESat-2) observatory.
@@ -979,8 +979,8 @@ class Query(GenQuery):
         >>> reg_a = ipx.Query('ATL06',[-55, 68, -48, 71],['2019-02-20','2019-02-28'])
         >>> reg_a.avail_granules()
         {'Number of available granules': 4,
-        'Average size of granules (MB)': 53.948360681525,
-        'Total size of all granules (MB)': 215.7934427261}
+        'Average size of granules (MB)': 55.166646003723145,
+        'Total size of all granules (MB)': 220.66658401489258}
 
         >>> reg_a = ipx.Query('ATL06',[-55, 68, -48, 71],['2019-02-20','2019-02-23'])
         >>> reg_a.avail_granules(ids=True)

--- a/icepyx/core/query.py
+++ b/icepyx/core/query.py
@@ -777,7 +777,7 @@ class Query(GenQuery):
         time_start :  2018-10-14T00:00:00.000Z
         coordinate_system :  CARTESIAN
         summary :  This data set (ATL06) provides geolocated, land-ice surface heights (above the WGS 84 ellipsoid, ITRF2014 reference frame), plus ancillary parameters that can be used to interpret and assess the quality of the height estimates. The data were acquired by the Advanced Topographic Laser Altimeter System (ATLAS) instrument on board the Ice, Cloud and land Elevation Satellite-2 (ICESat-2) observatory.
-        orbit_parameters :  {'swath_width': '36.0', 'period': '96.8', 'inclination_angle': '92.0', 'number_of_orbits': '0.071428571', 'start_circular_latitude': '0.0'}
+        orbit_parameters :  {}
         """
         if not hasattr(self, "_about_product"):
             self._about_product = is2ref.about_product(self._prod)

--- a/icepyx/core/query.py
+++ b/icepyx/core/query.py
@@ -997,7 +997,7 @@ class Query(GenQuery):
         try:
             self.granules.avail
         except AttributeError:
-            self.granules.get_avail(self.CMRparams, self.reqparams, cloud=True)
+            self.granules.get_avail(self.CMRparams, self.reqparams)
 
         if ids or cycles or tracks or cloud:
             # list of outputs in order of ids, cycles, tracks, cloud

--- a/icepyx/core/query.py
+++ b/icepyx/core/query.py
@@ -771,7 +771,7 @@ class Query(GenQuery):
         --------
         >>> reg_a = ipx.Query('ATL06',[-55, 68, -48, 71],['2019-02-20','2019-02-28'], version='006')
         >>> reg_a.product_summary_info()
-        title :  ATLAS/ICESat-2 L3A Land Ice Height V005
+        title :  ATLAS/ICESat-2 L3A Land Ice Height V006
         short_name :  ATL06
         version_id :  006
         time_start :  2018-10-14T00:00:00.000Z

--- a/icepyx/core/query.py
+++ b/icepyx/core/query.py
@@ -769,7 +769,7 @@ class Query(GenQuery):
 
         Examples
         --------
-        >>> reg_a = ipx.Query('ATL06',[-55, 68, -48, 71],['2019-02-20','2019-02-28'], version='005')
+        >>> reg_a = ipx.Query('ATL06',[-55, 68, -48, 71],['2019-02-20','2019-02-28'], version='006')
         >>> reg_a.product_summary_info()
         title :  ATLAS/ICESat-2 L3A Land Ice Height V005
         short_name :  ATL06
@@ -816,7 +816,7 @@ class Query(GenQuery):
         --------
         >>> reg_a = ipx.Query('ATL06',[-55, 68, -48, 71],['2019-02-20','2019-02-28'])
         >>> reg_a.latest_version()
-        '005'
+        '006'
         """
         if not hasattr(self, "_about_product"):
             self._about_product = is2ref.about_product(self._prod)
@@ -984,7 +984,7 @@ class Query(GenQuery):
 
         >>> reg_a = ipx.Query('ATL06',[-55, 68, -48, 71],['2019-02-20','2019-02-23'])
         >>> reg_a.avail_granules(ids=True)
-        [['ATL06_20190221121851_08410203_005_01.h5', 'ATL06_20190222010344_08490205_005_01.h5']]
+        [['ATL06_20190221121851_08410203_006_01.h5', 'ATL06_20190222010344_08490205_006_01.h5']]
         >>> reg_a.avail_granules(cycles=True)
         [['02', '02']]
         >>> reg_a.avail_granules(tracks=True)

--- a/icepyx/core/query.py
+++ b/icepyx/core/query.py
@@ -997,7 +997,7 @@ class Query(GenQuery):
         try:
             self.granules.avail
         except AttributeError:
-            self.granules.get_avail(self.CMRparams, self.reqparams, cloud=cloud)
+            self.granules.get_avail(self.CMRparams, self.reqparams, cloud=True)
 
         if ids or cycles or tracks or cloud:
             # list of outputs in order of ids, cycles, tracks, cloud


### PR DESCRIPTION
In some cases, if a CMR query was submitted for on-prem data (`{'provider':'NSIDC_ECS'}`), s3 urls were not available in the returned metadata. Since a separate request is submitted for downloading on-prem data (which has subsetting capabilities not available in the cloud), this PR defaults to using `{'provider':'NSIDC_CPRD'}` (the cumulus production provider - data download and streaming from an s3 bucket) in all metadata requests.