### PR TITLE
fix spot number calculation

### DIFF
--- a/icepyx/core/is2ref.py
+++ b/icepyx/core/is2ref.py
@@ -265,8 +265,11 @@ def _default_varlists(product):
         return common_list
 
 
-# dev goal: check and test this function
 def gt2spot(gt, sc_orient):
+    warnings.warn(
+        "icepyx versions 0.8.0 and earlier used an incorrect spot number calculation.",
+        "As a result, computations depending on spot number may be incorrect and should be redone.",
+    )
 
     assert gt in [
         "gt1l",
@@ -280,12 +283,13 @@ def gt2spot(gt, sc_orient):
     gr_num = np.uint8(gt[2])
     gr_lr = gt[3]
 
+    # spacecraft oriented forward
     if sc_orient == 1:
         if gr_num == 1:
             if gr_lr == "l":
-                spot = 2
+                spot = 6
             elif gr_lr == "r":
-                spot = 1
+                spot = 5
         elif gr_num == 2:
             if gr_lr == "l":
                 spot = 4
@@ -293,16 +297,17 @@ def gt2spot(gt, sc_orient):
                 spot = 3
         elif gr_num == 3:
             if gr_lr == "l":
-                spot = 6
+                spot = 2
             elif gr_lr == "r":
-                spot = 5
+                spot = 1
 
+    # spacecraft oriented backward
     elif sc_orient == 0:
         if gr_num == 1:
             if gr_lr == "l":
-                spot = 5
+                spot = 1
             elif gr_lr == "r":
-                spot = 6
+                spot = 2
         elif gr_num == 2:
             if gr_lr == "l":
                 spot = 3
@@ -310,9 +315,9 @@ def gt2spot(gt, sc_orient):
                 spot = 4
         elif gr_num == 3:
             if gr_lr == "l":
-                spot = 1
+                spot = 5
             elif gr_lr == "r":
-                spot = 2
+                spot = 6
 
     if "spot" not in locals():
         raise ValueError("Could not compute the spot number.")

--- a/icepyx/tests/test_is2ref.py
+++ b/icepyx/tests/test_is2ref.py
@@ -556,12 +556,12 @@ def test_unsupported_default_varlist():
 def test_gt2spot_sc_orient_1():
     # gt1l
     obs = is2ref.gt2spot("gt1l", 1)
-    expected = 2
+    expected = 6
     assert obs == expected
 
     # gt1r
     obs = is2ref.gt2spot("gt1r", 1)
-    expected = 1
+    expected = 5
     assert obs == expected
 
     # gt2l
@@ -576,24 +576,24 @@ def test_gt2spot_sc_orient_1():
 
     # gt3l
     obs = is2ref.gt2spot("gt3l", 1)
-    expected = 6
+    expected = 2
     assert obs == expected
 
     # gt3r
     obs = is2ref.gt2spot("gt3r", 1)
-    expected = 5
+    expected = 1
     assert obs == expected
 
 
 def test_gt2spot_sc_orient_0():
     # gt1l
     obs = is2ref.gt2spot("gt1l", 0)
-    expected = 5
+    expected = 1
     assert obs == expected
 
     # gt1r
     obs = is2ref.gt2spot("gt1r", 0)
-    expected = 6
+    expected = 2
     assert obs == expected
 
     # gt2l
@@ -608,10 +608,10 @@ def test_gt2spot_sc_orient_0():
 
     # gt3l
     obs = is2ref.gt2spot("gt3l", 0)
-    expected = 1
+    expected = 5
     assert obs == expected
 
     # gt3r
     obs = is2ref.gt2spot("gt3r", 0)
-    expected = 2
+    expected = 6
     assert obs == expected


### PR DESCRIPTION
Recent addressing of a dev note brought to light the fact that internal spot number calculations were incorrect. Further investigation showed that this was [previously addressed](https://github.com/ICESat2-SlideRule/sliderule/commit/d051948547fc5b2de348bf63204b9ef59314ae89) in SlideRule (the function upon which the original icepyx implementation was based) and is now clearly displayed in a table in the [ATL03 ATBD](https://nsidc.org/sites/default/files/documents/technical-reference/icesat2_atl03_atbd_r005.pdf) (p128), but the changes did not make it upstream into icepyx at the time the error was discovered. This PR updates the spot number calculation and adds a warning for users.