### PR TITLE
Expand Variables class to read s3 urls

### DIFF
--- a/icepyx/core/query.py
+++ b/icepyx/core/query.py
@@ -349,6 +349,10 @@ class Query(GenQuery, EarthdataAuthMixin):
         reference ground tracks are used. Example: "0594"
     files : string, default None
         A placeholder for future development. Not used for any purposes yet.
+    auth : earthaccess.auth.Auth, default None
+        An earthaccess authentication object. Available as an argument so an existing 
+        earthaccess.auth.Auth object can be used for authentication. If not given, a new auth 
+        object will be created whenever authentication is needed. 
 
     Returns
     -------


### PR DESCRIPTION
## Goal

This PR generalizes the Variables class to display available variables from an s3 path. If an s3 path is given the Variables class uses the product and version to display available variables; it does not try to walk through the file and build a the variables tree.

## How it was done

So simply! I'm excited about how easy this was, because it shows how worth it the efforts were to 1) create an auth Mixin and 2) make Variables an independent class 🙂

The biggest changes were in `is2ref.py`, in which the `extract_product` and `extract_version` functions were generalized to read from s3. They now accept an optional `auth` argument.

## How it can be tested
```python
from icepyx.core.variables import Variables

s3_path = 's3://nsidc-cumulus-prod-protected/ATLAS/ATL09/006/2019/11/30/ATL09_20191130215436_09930501_006_01.h5'
v = Variables(path=s3_path)
print(v.product)
print(v.version)
v.avail()
```
As a template for anyone ever writing future tests, the extract_product and extract_version functions should also be tested, for example as:
```python
import earthaccess
from icepyx.core.is2ref import extract_product

auth = earthaccess.login()
s3_path = 's3://nsidc-cumulus-prod-protected/ATLAS/ATL09/006/2019/11/30/ATL09_20191130215436_09930501_006_01.h5'
extract_product(s3_path, auth=auth)
```

## Notes

This is a draft PR for 2 reasons:
1. I think we should wait until #451 is merged to review this PR
2. Something is going on with the API endpoint that lists the variable paths (`ConnectionRefusedError ` https://n5eil02u.ecs.nsidc.org/egi/capabilities/ATL09.006.xml seems to be unresponsive). I'm hoping that if I check back in tomorrow that issue may be resolved 🤞🏻