### PR TITLE
fix ATL08 delta_time dimension read error

### DIFF
--- a/icepyx/core/read.py
+++ b/icepyx/core/read.py
@@ -616,11 +616,12 @@ class Read:
         except (AttributeError, KeyError):
             pass
 
-        try:
-            is2ds = is2ds.assign(ds[grp_spec_vars])
-        except xr.MergeError:
-            ds = ds[grp_spec_vars].reset_coords()
-            is2ds = is2ds.assign(ds)
+        ds = ds[grp_spec_vars].reset_coords()
+        is2ds = is2ds.assign(ds)
+
+        # manually remove delta time as a dimension
+        if "delta_time" in is2ds.dims:
+            is2ds = is2ds.drop_dims("delta_time")
 
         return is2ds
 

--- a/icepyx/core/read.py
+++ b/icepyx/core/read.py
@@ -279,7 +279,7 @@ class Read:
         String that shows the filename pattern as required for Intake's path_as_pattern argument.
         The default describes files downloaded directly from NSIDC (subsetted and non-subsetted) for most products (e.g. ATL06).
         The ATL11 filename pattern from NSIDC is: 'ATL{product:2}_{rgt:4}{orbitsegment:2}_{cycles:4}_{version:3}_{revision:2}.h5'.
-        
+
     catalog : string, default None
         Full path to an Intake catalog for reading in data.
         If you still need to create a catalog, leave as default.
@@ -313,8 +313,8 @@ class Read:
         # Raise error for depreciated argument
         if catalog:
             raise DeprecationError(
-                'The `catalog` argument has been deprecated and intake is no longer supported. '
-                'Please use the `data_source` argument to specify your dataset instead.'
+                "The `catalog` argument has been deprecated and intake is no longer supported. "
+                "Please use the `data_source` argument to specify your dataset instead."
             )
 
         if data_source is None:
@@ -616,9 +616,6 @@ class Read:
         except (AttributeError, KeyError):
             pass
 
-        # try:
-        #     is2ds = is2ds.assign(ds[grp_spec_vars])
-        # except xr.MergeError:
         ds = ds[grp_spec_vars].reset_coords()
         is2ds = is2ds.assign(ds)
 

--- a/icepyx/core/read.py
+++ b/icepyx/core/read.py
@@ -616,6 +616,9 @@ class Read:
         except (AttributeError, KeyError):
             pass
 
+        # try:
+        #     is2ds = is2ds.assign(ds[grp_spec_vars])
+        # except xr.MergeError:
         ds = ds[grp_spec_vars].reset_coords()
         is2ds = is2ds.assign(ds)
 


### PR DESCRIPTION
Per #376, #466, and #469 ATL08 data could not be read in.

During a read in of one of the deeply nested group variables, delta_time was being turned into a dimension (rather than staying as coordinates), causing merge conflicts when added to portions of the dataset that only had delta_time as coordinates due to the conflicting sizes of the delta_time coordinate. By dropping the delta_time dimension, we are able to merge properly.

This PR is being submitted as a patch bug fix directly to main in order to create a patch 0.8.1 release for an upcoming workshop.