### PR TITLE
Convert deprecation warnings to errors

### DIFF
--- a/icepyx/core/icesat2data.py
+++ b/icepyx/core/icesat2data.py
@@ -1,12 +1,10 @@
-import warnings
+from icepyx.core.exceptions import DeprecationError
 
 
 class Icesat2Data:
     def __init__(
         self,
     ):
-        warnings.filterwarnings("always")
-        warnings.warn(
+        DeprecationError(
             "DEPRECATED. Please use icepyx.Query to create a download data object (all other functionality is the same)",
-            DeprecationWarning,
         )

--- a/icepyx/core/query.py
+++ b/icepyx/core/query.py
@@ -2,10 +2,10 @@ import geopandas as gpd
 import matplotlib.pyplot as plt
 from pathlib import Path  # used in docstring tests
 import pprint
-import warnings
 
 import icepyx.core.APIformatting as apifmt
 from icepyx.core.auth import EarthdataAuthMixin
+from icepyx.core.exceptions import DeprecationError
 import icepyx.core.granules as granules
 from icepyx.core.granules import Granules
 import icepyx.core.is2ref as is2ref
@@ -455,10 +455,8 @@ class Query(GenQuery, EarthdataAuthMixin):
         --------
         product
         """
-        warnings.filterwarnings("always")
-        warnings.warn(
+        DeprecationError(
             "In line with most common usage, 'dataset' has been replaced by 'product'.",
-            DeprecationWarning,
         )
 
     @property

--- a/icepyx/core/read.py
+++ b/icepyx/core/read.py
@@ -3,7 +3,6 @@ import glob
 import os
 import warnings
 
-import h5py
 import numpy as np
 import xarray as xr
 
@@ -157,9 +156,9 @@ def _validate_source(source):
     # acceptable inputs (for now) are a single file or directory
     # would ultimately like to make a Path (from pathlib import Path; isinstance(source, Path)) an option
     # see https://github.com/OSOceanAcoustics/echopype/blob/ab5128fb8580f135d875580f0469e5fba3193b84/echopype/utils/io.py#L82
-    assert type(source) == str, "You must enter your input as a string."
+    assert type(source) is str, "You must enter your input as a string."
     assert (
-        os.path.isdir(source) == True or os.path.isfile(source) == True
+        os.path.isdir(source) is True or os.path.isfile(source) is True
     ), "Your data source string is not a valid data source."
     return True
 
@@ -323,7 +322,7 @@ class Read:
 
     def __init__(
         self,
-        data_source=None,  # DevNote: Make this a required arg when catalog is removed
+        data_source,
         product=None,
         filename_pattern=None,
         catalog=None,
@@ -339,23 +338,21 @@ class Read:
 
         if data_source is None:
             raise ValueError("data_source is a required arguemnt")
+
         # Raise warnings for deprecated arguments
         if filename_pattern:
-            warnings.warn(
+            raise DeprecationError(
                 "The `filename_pattern` argument is deprecated. Instead please provide a "
-                "string, list, or glob string to the `data_source` argument.",
-                stacklevel=2,
+                "string, list, or glob string to the `data_source` argument."
             )
 
         if product:
-            product = is2ref._validate_product(product)
-            warnings.warn(
+            raise DeprecationError(
                 "The `product` argument is no longer required. If the `data_source` argument given "
                 "contains files with multiple products the `product` argument will be used "
                 "to filter that list. In all other cases the product argument is ignored. "
                 "The recommended approach is to not include a `product` argument and instead "
-                "provide a `data_source` with files of only a single product type`.",
-                stacklevel=2,
+                "provide a `data_source` with files of only a single product type`."
             )
 
         # Create the filelist from the `data_source` argument

--- a/icepyx/core/read.py
+++ b/icepyx/core/read.py
@@ -356,14 +356,14 @@ class Read:
             )
 
         # Create the filelist from the `data_source` argument
-        if filename_pattern:
-            # maintained for backward compatibility
-            pattern_ck, filelist = Read._check_source_for_pattern(
-                data_source, filename_pattern
-            )
-            assert pattern_ck
-            self._filelist = filelist
-        elif isinstance(data_source, list):
+        # if filename_pattern:
+        #     # maintained for backward compatibility
+        #     pattern_ck, filelist = Read._check_source_for_pattern(
+        #         data_source, filename_pattern
+        #     )
+        #     assert pattern_ck
+        #     self._filelist = filelist
+        if isinstance(data_source, list):
             self._filelist = data_source
         elif os.path.isdir(data_source):
             data_source = os.path.join(data_source, "*")
@@ -381,31 +381,32 @@ class Read:
         # Raise warnings or errors for multiple products or products not matching the user-specified product
         all_products = list(set(product_dict.values()))
         if len(all_products) > 1:
-            if product:
-                warnings.warn(
-                    f"Multiple products found in list of files: {product_dict}. Files that "
-                    "do not match the user specified product will be removed from processing.\n"
-                    "Filtering files using a `product` argument is deprecated. Please use the "
-                    "`data_source` argument to specify a list of files with the same product.",
-                    stacklevel=2,
-                )
-                self._filelist = []
-                for key, value in product_dict.items():
-                    if value == product:
-                        self._filelist.append(key)
-                if len(self._filelist) == 0:
-                    raise TypeError(
-                        "No files found in the file list matching the user-specified "
-                        "product type"
-                    )
-                # Use the cleaned filelist to assign a product
-                self._product = product
-            else:
-                raise TypeError(
-                    f"Multiple product types were found in the file list: {product_dict}."
-                    "Please provide a valid `data_source` parameter indicating files of a single "
-                    "product"
-                )
+            # Should this code be removed now, or when the deprecation error for the arg is?
+            # if product:
+            #     warnings.warn(
+            #         f"Multiple products found in list of files: {product_dict}. Files that "
+            #         "do not match the user specified product will be removed from processing.\n"
+            #         "Filtering files using a `product` argument is deprecated. Please use the "
+            #         "`data_source` argument to specify a list of files with the same product.",
+            #         stacklevel=2,
+            #     )
+            #     self._filelist = []
+            #     for key, value in product_dict.items():
+            #         if value == product:
+            #             self._filelist.append(key)
+            #     if len(self._filelist) == 0:
+            #         raise TypeError(
+            #             "No files found in the file list matching the user-specified "
+            #             "product type"
+            #         )
+            #     # Use the cleaned filelist to assign a product
+            #     self._product = product
+            # else:
+            raise TypeError(
+                f"Multiple product types were found in the file list: {product_dict}."
+                "Please provide a valid `data_source` parameter indicating files of a single "
+                "product"
+            )
         elif len(all_products) == 0:
             raise TypeError(
                 "No files found matching the specified `data_source`. Check your glob "
@@ -414,13 +415,13 @@ class Read:
         else:
             # Assign the identified product to the property
             self._product = all_products[0]
-        # Raise a warning if the metadata-located product differs from the user-specified product
-        if product and self._product != product:
-            warnings.warn(
-                f"User specified product {product} does not match the product from the file"
-                " metadata {self._product}",
-                stacklevel=2,
-            )
+        # # Raise a warning if the metadata-located product differs from the user-specified product
+        # if product and self._product != product:
+        #     warnings.warn(
+        #         f"User specified product {product} does not match the product from the file"
+        #         " metadata {self._product}",
+        #         stacklevel=2,
+        #     )
 
         if out_obj_type is not None:
             print(
@@ -431,8 +432,6 @@ class Read:
 
     # ----------------------------------------------------------------------
     # Properties
-
-    # I cut and pasted this directly out of the Query class - going to need to reconcile the _source/file stuff there
 
     @property
     def vars(self):
@@ -743,11 +742,7 @@ class Read:
             pass
 
         all_dss = []
-        # DevNote: I'd originally hoped to rely on intake-xarray in order to not have to iterate through the files myself,
-        # by providing a generalized url/source in building the catalog.
-        # However, this led to errors when I tried to combine two identical datasets because the single dimension was equal.
-        # In these situations, xarray recommends manually controlling the merge/concat process yourself.
-        # While unlikely to be a broad issue, I've heard of multiple matching timestamps causing issues for combining multiple IS2 datasets.
+
         for file in self.filelist:
             all_dss.append(
                 self._build_single_file_dataset(file, groups_list)


### PR DESCRIPTION
icepyx has a series of deprecations that are still warnings. Some are new deprecations during the modifications for cloud reading, and some are stale but were never turned into errors prior to planned removal. This PR aims to turn all current deprecations into errors for the v1 release, with planned removal of the errors in a future minor release.