### PR TITLE
fix permissions for OIDC publishing to pypi

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Publish to Test PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        repository_url: https://test.pypi.org/legacy/
+        repository-url: https://test.pypi.org/legacy/
 
     - name: Publish to PyPI
       if: startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -17,6 +17,8 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     if: github.repository == 'icesat2py/icepyx'
+    permissions:
+      id-token: write
 
     steps:
     - name: Checkout
@@ -51,13 +53,9 @@ jobs:
 
     - name: Publish to Test PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      permissions:
-        id-token: write
       with:
         repository_url: https://test.pypi.org/legacy/
 
     - name: Publish to PyPI
       if: startsWith(github.ref, 'refs/tags')
-      permissions:
-        id-token: write
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
The action failed when merged into development. It looks like the permissions flag gets added at a higher level. This PR aims to fix that.