### PR TITLE
update codecov uploader to start getting coverage reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,16 @@ jobs:
   include:
     - stage: basic tests
       script: pytest icepyx/ --verbose --cov app --ignore icepyx/tests/test_behind_NSIDC_API_login.py
-      after_success: codecov/codecov-action@v3
-
+      # includes an integrity check of the uploader as recommended by CodeCov
+      after_success:
+        - curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
+        - curl -Os https://uploader.codecov.io/latest/linux/codecov
+        - curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+        - curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+        - gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+        - shasum -a 256 -c codecov.SHA256SUM 
+        - chmod +x codecov
+        - ./codecov -t ${CODECOV_TOKEN}
     - stage: behind Earthdata
       script:
         - export EARTHDATA_PASSWORD=$NSIDC_LOGIN


### PR DESCRIPTION
At some point we stopped getting code testing coverage reports (it was failing silently in Travis CI). This PR updates to use the most recent uploader. Addresses #485.

References:
- https://docs.codecov.com/docs/codecov-uploader#integrity-checking-the-uploader