### PR TITLE
fix black linter failures with action update

### DIFF
--- a/doc/sphinxext/contributors.py
+++ b/doc/sphinxext/contributors.py
@@ -13,6 +13,7 @@ use::
 While the v0.23.1 tag does not exist, that will use the HEAD of the
 branch as the end of the revision range.
 """
+
 from announce import build_components
 from docutils import nodes
 from docutils.parsers.rst import Directive

--- a/icepyx/core/visualization.py
+++ b/icepyx/core/visualization.py
@@ -2,8 +2,6 @@
 Interactive visualization of spatial extent and ICESat-2 elevations
 """
 import concurrent.futures
-import datetime
-import re
 import warnings
 
 import backoff

--- a/icepyx/core/visualization.py
+++ b/icepyx/core/visualization.py
@@ -1,6 +1,7 @@
 """
 Interactive visualization of spatial extent and ICESat-2 elevations
 """
+
 import concurrent.futures
 import warnings
 

--- a/icepyx/quest/dataset_scripts/dataset.py
+++ b/icepyx/quest/dataset_scripts/dataset.py
@@ -4,7 +4,6 @@ warnings.filterwarnings("ignore")
 
 
 class DataSet:
-
     """
     Template parent class for all QUEST supported datasets (i.e. ICESat-2, Argo BGC, Argo, MODIS, etc.).
     All sub-classes must support the following methods for use via the QUEST class.

--- a/icepyx/quest/dataset_scripts/dataset.py
+++ b/icepyx/quest/dataset_scripts/dataset.py
@@ -1,5 +1,4 @@
 import warnings
-from icepyx.core.query import GenQuery
 
 warnings.filterwarnings("ignore")
 


### PR DESCRIPTION
Checks that passed yesterday are failing today even without changes to the files causing the failures. Specifically, running black locally results in no reformatting, but then the linting action fails. Likely related to https://github.com/psf/black/issues/4173 and the update of the action to v24.1.0. This PR manually fixes the newline issues causing the linting check failures.