### PR TITLE
Updating the "QUEST Available Datasets" page

### DIFF
--- a/doc/source/contributing/quest-available-datasets.rst
+++ b/doc/source/contributing/quest-available-datasets.rst
@@ -13,7 +13,7 @@ List of Datasets
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The Argo mission involves a series of floats that are designed to capture vertical ocean profiles of temperature, salinity, and pressure down to ~2000 m. Some floats are in support of BGC-Argo, which also includes data relevant for biogeochemical applications: oxygen, nitrate, chlorophyll, backscatter, and solar irradiance.
 
-A paper outlining QUEST and its application to Argo data access is currently under review at AGU Earth and Space Science. Interested readers may find the citable preprint here: <doi.org/10.22541/au.170258908.81399744/v1>.
+A paper outlining QUEST and its application to Argo data access is currently under review at AGU Earth and Space Science. Interested readers may find the citable preprint here: <https://doi.org/10.22541/au.170258908.81399744/v1>
 
 `Argo Workflow Example <https://icepyx.readthedocs.io/en/latest/example_notebooks/QUEST_argo_data_access.html>`_
 

--- a/doc/source/contributing/quest-available-datasets.rst
+++ b/doc/source/contributing/quest-available-datasets.rst
@@ -13,7 +13,7 @@ List of Datasets
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The Argo mission involves a series of floats that are designed to capture vertical ocean profiles of temperature, salinity, and pressure down to ~2000 m. Some floats are in support of BGC-Argo, which also includes data relevant for biogeochemical applications: oxygen, nitrate, chlorophyll, backscatter, and solar irradiance.
 
-For interested readers, a preprint outlining the QUEST and its application to Argo data access is available here: <https://doi.org/10.22541/au.170258908.81399744/v1>
+For interested readers, a preprint outlining the QUEST module and its application to Argo data access is available `here <https://doi.org/10.22541/au.170258908.81399744/v1>`_.
 
 `Argo Workflow Example <https://icepyx.readthedocs.io/en/latest/example_notebooks/QUEST_argo_data_access.html>`_
 

--- a/doc/source/contributing/quest-available-datasets.rst
+++ b/doc/source/contributing/quest-available-datasets.rst
@@ -15,7 +15,7 @@ The Argo mission involves a series of floats that are designed to capture vertic
 
 A paper outlining the Argo extension to QUEST is currently in preparation, with a citable preprint available in the near future.
 
-:ref:`Argo Workflow Example<quest_workbook_label>`
+Argo Workflow Example:ref:`quest_workbook_label`
 
 
 Adding a Dataset to QUEST

--- a/doc/source/contributing/quest-available-datasets.rst
+++ b/doc/source/contributing/quest-available-datasets.rst
@@ -13,7 +13,7 @@ List of Datasets
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The Argo mission involves a series of floats that are designed to capture vertical ocean profiles of temperature, salinity, and pressure down to ~2000 m. Some floats are in support of BGC-Argo, which also includes data relevant for biogeochemical applications: oxygen, nitrate, chlorophyll, backscatter, and solar irradiance.
 
-A paper outlining QUEST and its application to Argo data access is currently under review at AGU Earth and Space Science. Interested readers may find the citable preprint here: doi.org/10.22541/au.170258908.81399744/v1,
+A paper outlining QUEST and its application to Argo data access is currently under review at AGU Earth and Space Science. Interested readers may find the citable preprint here: <doi.org/10.22541/au.170258908.81399744/v1>.
 
 `Argo Workflow Example <https://icepyx.readthedocs.io/en/latest/example_notebooks/QUEST_argo_data_access.html>`_
 

--- a/doc/source/contributing/quest-available-datasets.rst
+++ b/doc/source/contributing/quest-available-datasets.rst
@@ -13,7 +13,7 @@ List of Datasets
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The Argo mission involves a series of floats that are designed to capture vertical ocean profiles of temperature, salinity, and pressure down to ~2000 m. Some floats are in support of BGC-Argo, which also includes data relevant for biogeochemical applications: oxygen, nitrate, chlorophyll, backscatter, and solar irradiance.
 
-A paper outlining the Argo extension to QUEST is currently in preparation, with a citable preprint available in the near future.
+A paper outlining QUEST and its application to Argo data access is currently under review at AGU Earth and Space Science. Interested readers may find the citable preprint here: doi.org/10.22541/au.170258908.81399744/v1,
 
 `Argo Workflow Example <https://icepyx.readthedocs.io/en/latest/example_notebooks/QUEST_argo_data_access.html>`_
 

--- a/doc/source/contributing/quest-available-datasets.rst
+++ b/doc/source/contributing/quest-available-datasets.rst
@@ -15,7 +15,7 @@ The Argo mission involves a series of floats that are designed to capture vertic
 
 A paper outlining the Argo extension to QUEST is currently in preparation, with a citable preprint available in the near future.
 
-Argo Workflow Example:ref:`quest_workbook_label`
+`Argo Workflow Example <https://icepyx.readthedocs.io/en/latest/example_notebooks/QUEST_argo_data_access.html>`_
 
 
 Adding a Dataset to QUEST

--- a/doc/source/contributing/quest-available-datasets.rst
+++ b/doc/source/contributing/quest-available-datasets.rst
@@ -13,7 +13,7 @@ List of Datasets
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The Argo mission involves a series of floats that are designed to capture vertical ocean profiles of temperature, salinity, and pressure down to ~2000 m. Some floats are in support of BGC-Argo, which also includes data relevant for biogeochemical applications: oxygen, nitrate, chlorophyll, backscatter, and solar irradiance.
 
-A paper outlining QUEST and its application to Argo data access is currently under review at AGU Earth and Space Science. Interested readers may find the citable preprint here: <https://doi.org/10.22541/au.170258908.81399744/v1>
+For interested readers, a preprint outlining the QUEST and its application to Argo data access is available here: <https://doi.org/10.22541/au.170258908.81399744/v1>
 
 `Argo Workflow Example <https://icepyx.readthedocs.io/en/latest/example_notebooks/QUEST_argo_data_access.html>`_
 


### PR DESCRIPTION
I noticed that the webpage for "QUEST Supported Datasets" was a bit out of date relative to developments from December, namely the updated Argo workbook and the paper submission. I made some quick updates to provide links to the workbook and the AGU ESS preprint for interested readers/users.