### PR TITLE
add dependency needed to build packages

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -33,7 +33,7 @@ jobs:
         python-version: 3.9
 
     - name: Install dependencies
-      run: python -m pip install setuptools wheel
+      run: python -m pip install build setuptools wheel
 
     # This step is only necessary for testing purposes and for TestPyPI
     - name: Fix up version string for TestPyPI


### PR DESCRIPTION
In #500 we transitioned to not calling `setup.py` directly, using build [as recommended](https://packaging.python.org/en/latest/guides/modernize-setup-py-project/). This PR adds the needed build module to the GH action.