### PR TITLE
add dask[dataframe] to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 backoff
+dask[dataframe]
 datashader
 earthaccess>=0.5.1
 fiona


### PR DESCRIPTION
Per [this note](https://github.com/icesat2py/icepyx/pull/498#issuecomment-1992180114) we need to add dask dataframe as an explicit dependency.