### PR TITLE
Remove unnecessary argument due to the Granules.download() update

### DIFF
--- a/icepyx/core/query.py
+++ b/icepyx/core/query.py
@@ -1110,7 +1110,7 @@ class Query(GenQuery, EarthdataAuthMixin):
             ):
                 self.order_granules(verbose=verbose, subset=subset, **kwargs)
 
-        self._granules.download(verbose, path, session=self.session, restart=restart)
+        self._granules.download(verbose, path, restart=restart)
 
     # DevGoal: add testing? What do we test, and how, given this is a visualization.
     # DevGoal(long term): modify this to accept additional inputs, etc.


### PR DESCRIPTION
This solves the issue I mentioned in #515, and with this change, I finally downloaded the ATL11 data using icepyx. 