### PR TITLE
update docstring tests for numpy 2.0

### DIFF
--- a/icepyx/core/is2ref.py
+++ b/icepyx/core/is2ref.py
@@ -271,6 +271,10 @@ def _default_varlists(product):
         return common_list
 
 
+# Currently this function is used one-off, but if it needs to be done for a series of values,
+# a faster version using pandas map (instead of apply) is available in SlideRule:
+# https://github.com/SlideRuleEarth/sliderule/issues/388
+# https://github.com/SlideRuleEarth/sliderule/commit/46cceac0e5f6d0a580933d399a6239bc911757f3
 def gt2spot(gt, sc_orient):
     warnings.warn(
         "icepyx versions 0.8.0 and earlier used an incorrect spot number calculation."

--- a/icepyx/core/query.py
+++ b/icepyx/core/query.py
@@ -914,7 +914,7 @@ class Query(GenQuery, EarthdataAuthMixin):
         >>> reg_a = ipx.Query('ATL06',[-55, 68, -48, 71],['2019-02-20','2019-02-28'])
         >>> reg_a.avail_granules()
         {'Number of available granules': 4,
-        'Average size of granules (MB)': 55.166646003723145,
+        'Average size of granules (MB)': np.float64(55.166646003723145),
         'Total size of all granules (MB)': 220.66658401489258}
 
         >>> reg_a = ipx.Query('ATL06',[-55, 68, -48, 71],['2019-02-20','2019-02-23'])

--- a/icepyx/core/spatial.py
+++ b/icepyx/core/spatial.py
@@ -49,7 +49,7 @@ def geodataframe(extent_type, spatial_extent, file=False, xdateline=None):
     >>> reg_a = ipx.Query('ATL06',[-55, 68, -48, 71],['2019-02-20','2019-02-28'])
     >>> gdf = geodataframe(reg_a.spatial.extent_type, reg_a.spatial.extent)
     >>> gdf.geometry
-    0    POLYGON ((-48.00000 68.00000, -48.00000 71.000...
+    0    POLYGON ((-48 68, -48 71, -55 71, -55 68, -48 ...
     Name: geometry, dtype: geometry
     """
 


### PR DESCRIPTION
A few docstring tests started failing due to differences in `__repr__` after the switch to numpy >= 2.0 on CI. This PR fixes those.