### PR TITLE
Switch to set comparison to fix a test dependent on unreliable order

### DIFF
--- a/icepyx/tests/test_quest_argo.py
+++ b/icepyx/tests/test_quest_argo.py
@@ -59,8 +59,8 @@ def test_param_setter(argo_quest_instance):
 
     reg_a.params = ["temperature", "salinity"]
 
-    exp = ["temperature", "salinity"]
-    assert reg_a.params == exp
+    exp = {"temperature", "salinity"}
+    assert set(reg_a.params) == exp
 
 
 def test_param_setter_invalid_inputs(argo_quest_instance):


### PR DESCRIPTION
> [!NOTE]
> I'm not sure this is the right decision! Should we instead change the setter so that it preserves order of parameters passed in?