### PR TITLE
`test_auth.py`: Skip three pytests that fail on Travis CI

### DIFF
--- a/icepyx/tests/test_auth.py
+++ b/icepyx/tests/test_auth.py
@@ -8,7 +8,9 @@ import earthaccess
 from icepyx.core.auth import EarthdataAuthMixin
 
 # Are we running on Travis CI?
-TRAVIS = os.environ.get("TRAVIS") == "true"
+skip_if_travis_ci = pytest.mark.skipif(
+    os.environ.get("TRAVIS") == "true", reason="Skipping this test on Travis CI."
+)
 
 
 @pytest.fixture()
@@ -21,13 +23,13 @@ def auth_instance():
 
 
 # Test that .session creates a session
-@pytest.mark.skipif(TRAVIS, reason="Skipping this test on Travis CI.")
+@skip_if_travis_ci
 def test_get_session(auth_instance):
     assert isinstance(auth_instance.session, requests.sessions.Session)
 
 
 # Test that .s3login_credentials creates a dict with the correct keys
-@pytest.mark.skipif(TRAVIS, reason="Skipping this test on Travis CI.")
+@skip_if_travis_ci
 def test_get_s3login_credentials(auth_instance):
     assert isinstance(auth_instance.s3login_credentials, dict)
     expected_keys = set(
@@ -37,7 +39,7 @@ def test_get_s3login_credentials(auth_instance):
 
 
 # Test that earthdata_login generates an auth object
-@pytest.mark.skipif(TRAVIS, reason="Skipping this test on Travis CI.")
+@skip_if_travis_ci
 def test_login_function(auth_instance):
     assert isinstance(auth_instance.auth, earthaccess.auth.Auth)
     assert auth_instance.auth.authenticated

--- a/icepyx/tests/test_auth.py
+++ b/icepyx/tests/test_auth.py
@@ -7,6 +7,9 @@ import earthaccess
 
 from icepyx.core.auth import EarthdataAuthMixin
 
+# Are we running on Travis CI?
+TRAVIS = os.environ.get("TRAVIS") == "true"
+
 
 @pytest.fixture()
 def auth_instance():
@@ -18,16 +21,14 @@ def auth_instance():
 
 
 # Test that .session creates a session
-@pytest.mark.skipif(os.getenv("TRAVIS"), reason="Skipping this test on Travis CI.")
+@pytest.mark.skipif(TRAVIS, reason="Skipping this test on Travis CI.")
 def test_get_session(auth_instance):
     print(os.environ)
     assert isinstance(auth_instance.session, requests.sessions.Session)
 
 
 # Test that .s3login_credentials creates a dict with the correct keys
-@pytest.mark.skipif(
-    os.environ.get("TRAVIS") == "true", reason="Skipping this test on Travis CI."
-)
+@pytest.mark.skipif(TRAVIS, reason="Skipping this test on Travis CI.")
 def test_get_s3login_credentials(auth_instance):
     assert isinstance(auth_instance.s3login_credentials, dict)
     expected_keys = set(
@@ -37,9 +38,7 @@ def test_get_s3login_credentials(auth_instance):
 
 
 # Test that earthdata_login generates an auth object
-@pytest.mark.skipif(
-    os.environ.get("TRAVIS") == "true", reason="Skipping this test on Travis CI."
-)
+@pytest.mark.skipif(TRAVIS, reason="Skipping this test on Travis CI.")
 def test_login_function(auth_instance):
     assert isinstance(auth_instance.auth, earthaccess.auth.Auth)
     assert auth_instance.auth.authenticated

--- a/icepyx/tests/test_auth.py
+++ b/icepyx/tests/test_auth.py
@@ -7,7 +7,6 @@ import earthaccess
 
 from icepyx.core.auth import EarthdataAuthMixin
 
-# Are we running on Travis CI?
 skip_if_travis_ci = pytest.mark.skipif(
     os.environ.get("TRAVIS") == "true", reason="Skipping this test on Travis CI."
 )

--- a/icepyx/tests/test_auth.py
+++ b/icepyx/tests/test_auth.py
@@ -18,9 +18,7 @@ def auth_instance():
 
 
 # Test that .session creates a session
-@pytest.mark.skipif(
-    os.getenv("TRAVIS"), "Skipping this test on Travis CI."
-)
+@pytest.mark.skipif(os.getenv("TRAVIS"), "Skipping this test on Travis CI.")
 def test_get_session(auth_instance):
     print(os.environ)
     assert isinstance(auth_instance.session, requests.sessions.Session)

--- a/icepyx/tests/test_auth.py
+++ b/icepyx/tests/test_auth.py
@@ -18,15 +18,17 @@ def auth_instance():
 
 
 # Test that .session creates a session
-@pytest.mark.skipif(os.environ.get("TRAVIS") == "true",
-                    "Skipping this test on Travis CI.")
+@pytest.mark.skipif(
+    os.environ.get("TRAVIS") == "true", "Skipping this test on Travis CI."
+)
 def test_get_session(auth_instance):
     assert isinstance(auth_instance.session, requests.sessions.Session)
 
 
 # Test that .s3login_credentials creates a dict with the correct keys
-@pytest.mark.skipif(os.environ.get("TRAVIS") == "true",
-                    "Skipping this test on Travis CI.")
+@pytest.mark.skipif(
+    os.environ.get("TRAVIS") == "true", "Skipping this test on Travis CI."
+)
 def test_get_s3login_credentials(auth_instance):
     assert isinstance(auth_instance.s3login_credentials, dict)
     expected_keys = set(
@@ -36,8 +38,9 @@ def test_get_s3login_credentials(auth_instance):
 
 
 # Test that earthdata_login generates an auth object
-@pytest.mark.skipif(os.environ.get("TRAVIS") == "true",
-                    "Skipping this test on Travis CI.")
+@pytest.mark.skipif(
+    os.environ.get("TRAVIS") == "true", "Skipping this test on Travis CI."
+)
 def test_login_function(auth_instance):
     assert isinstance(auth_instance.auth, earthaccess.auth.Auth)
     assert auth_instance.auth.authenticated

--- a/icepyx/tests/test_auth.py
+++ b/icepyx/tests/test_auth.py
@@ -18,7 +18,7 @@ def auth_instance():
 
 
 # Test that .session creates a session
-@pytest.mark.skipif(os.getenv("TRAVIS"), "Skipping this test on Travis CI.")
+@pytest.mark.skipif(os.getenv("TRAVIS"), reason="Skipping this test on Travis CI.")
 def test_get_session(auth_instance):
     print(os.environ)
     assert isinstance(auth_instance.session, requests.sessions.Session)
@@ -26,7 +26,7 @@ def test_get_session(auth_instance):
 
 # Test that .s3login_credentials creates a dict with the correct keys
 @pytest.mark.skipif(
-    os.environ.get("TRAVIS") == "true", "Skipping this test on Travis CI."
+    os.environ.get("TRAVIS") == "true", reason="Skipping this test on Travis CI."
 )
 def test_get_s3login_credentials(auth_instance):
     assert isinstance(auth_instance.s3login_credentials, dict)
@@ -38,7 +38,7 @@ def test_get_s3login_credentials(auth_instance):
 
 # Test that earthdata_login generates an auth object
 @pytest.mark.skipif(
-    os.environ.get("TRAVIS") == "true", "Skipping this test on Travis CI."
+    os.environ.get("TRAVIS") == "true", reason="Skipping this test on Travis CI."
 )
 def test_login_function(auth_instance):
     assert isinstance(auth_instance.auth, earthaccess.auth.Auth)

--- a/icepyx/tests/test_auth.py
+++ b/icepyx/tests/test_auth.py
@@ -23,7 +23,6 @@ def auth_instance():
 # Test that .session creates a session
 @pytest.mark.skipif(TRAVIS, reason="Skipping this test on Travis CI.")
 def test_get_session(auth_instance):
-    print(os.environ)
     assert isinstance(auth_instance.session, requests.sessions.Session)
 
 

--- a/icepyx/tests/test_auth.py
+++ b/icepyx/tests/test_auth.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 import requests
 
@@ -16,11 +18,15 @@ def auth_instance():
 
 
 # Test that .session creates a session
+@pytest.mark.skipif(os.environ.get("TRAVIS") == "true",
+                    "Skipping this test on Travis CI.")
 def test_get_session(auth_instance):
     assert isinstance(auth_instance.session, requests.sessions.Session)
 
 
 # Test that .s3login_credentials creates a dict with the correct keys
+@pytest.mark.skipif(os.environ.get("TRAVIS") == "true",
+                    "Skipping this test on Travis CI.")
 def test_get_s3login_credentials(auth_instance):
     assert isinstance(auth_instance.s3login_credentials, dict)
     expected_keys = set(
@@ -30,6 +36,8 @@ def test_get_s3login_credentials(auth_instance):
 
 
 # Test that earthdata_login generates an auth object
+@pytest.mark.skipif(os.environ.get("TRAVIS") == "true",
+                    "Skipping this test on Travis CI.")
 def test_login_function(auth_instance):
     assert isinstance(auth_instance.auth, earthaccess.auth.Auth)
     assert auth_instance.auth.authenticated

--- a/icepyx/tests/test_auth.py
+++ b/icepyx/tests/test_auth.py
@@ -19,9 +19,10 @@ def auth_instance():
 
 # Test that .session creates a session
 @pytest.mark.skipif(
-    os.environ.get("TRAVIS") == "true", "Skipping this test on Travis CI."
+    os.getenv("TRAVIS"), "Skipping this test on Travis CI."
 )
 def test_get_session(auth_instance):
+    print(os.environ)
     assert isinstance(auth_instance.session, requests.sessions.Session)
 
 


### PR DESCRIPTION
Travis CI limits outbound network requests.

https://docs.travis-ci.com/user/environment-variables/#default-environment-variables