### PR TITLE
Avoid running tests that require creds on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ stages:
 jobs:
   include:
     - stage: basic tests
-      script: pytest icepyx/ --verbose --cov app --ignore icepyx/tests/test_behind_NSIDC_API_login.py
+      script: pytest icepyx/ --verbose --cov app --ignore=icepyx/tests/test_behind_NSIDC_API_login.py --ignore=icepyx/tests/test_auth.py
       # includes an integrity check of the uploader as recommended by CodeCov
       after_success:
         - curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
@@ -41,4 +41,4 @@ jobs:
     - stage: behind Earthdata
       script:
         - export EARTHDATA_PASSWORD=$NSIDC_LOGIN
-        - pytest icepyx/tests/test_behind_NSIDC_API_login.py
+        - pytest icepyx/tests/test_behind_NSIDC_API_login.py icepyx/tests/test_auth.py


### PR DESCRIPTION
Resolves #272 

Move test_auth.py into second stage which does not run on PRs

A better fix would be to control what runs based on whether the PR is from a fork. We can do that with GitHub Actions. See: #547 

I tested this by forking and opening a PR against this branch, and its CI passes: https://github.com/icesat2py/icepyx/pull/564