### PR TITLE
Skip linting and formatting Jupyter Notebooks for now

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         args: [--markdown-linebreak-ext=md]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.7
+    rev: v0.6.0
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,12 @@ version_file = "_icepyx_version.py"
 version_file_template = 'version = "{version}"'
 local_scheme = "node-and-date"
 fallback_version = "unknown"
+
+
+[tool.ruff]
+# DevGoal: Lint and format all Jupyter Notebooks, remove below.
+extend-exclude = ["*.ipynb"]
+
 # [tool.ruff.format]
 # docstring-code-format = true
 # docstring-code-line-length = "dynamic"


### PR DESCRIPTION
Ruff v0.6.0 turns on linting and formatting of Jupyter Notebooks by default. Disabling for now to keep moving on some other stuff :) https://astral.sh/blog/ruff-v0.6.0