### PR TITLE
Add ruff rules C4 to check comprehensions

### DIFF
--- a/doc/sphinxext/announce.py
+++ b/doc/sphinxext/announce.py
@@ -125,7 +125,7 @@ def get_authors(revision_range):
     #     pre.discard("Homu")
 
     # Append '+' to new authors.
-    authors = [s + " +" for s in cur - pre] + [s for s in cur & pre]
+    authors = [s + " +" for s in cur - pre] + list(cur & pre)
     authors.sort()
     return authors
 

--- a/icepyx/core/APIformatting.py
+++ b/icepyx/core/APIformatting.py
@@ -298,7 +298,7 @@ class Parameters:
         # if self._wanted == None:
         #     raise ValueError("No desired parameter list was passed")
 
-        val_list = list(set(val for lis in self.poss_keys.values() for val in lis))
+        val_list = list({val for lis in self.poss_keys.values() for val in lis})
 
         for key in self.fmted_keys.keys():
             assert key in val_list, (

--- a/icepyx/core/granules.py
+++ b/icepyx/core/granules.py
@@ -82,7 +82,7 @@ def gran_IDs(grans, ids=False, cycles=False, tracks=False, dates=False, cloud=Fa
             except KeyError:
                 pass
 
-        if any([param is True for param in [cycles, tracks, dates]]):
+        if any(param is True for param in [cycles, tracks, dates]):
             # PRD: ICESat-2 product
             # HEM: Sea Ice Hemisphere flag
             # YY,MM,DD,HH,MN,SS: Year, Month, Day, Hour, Minute, Second

--- a/icepyx/core/read.py
+++ b/icepyx/core/read.py
@@ -661,11 +661,11 @@ class Read(EarthdataAuthMixin):
         """
 
         is2ds = xr.Dataset(
-            coords=dict(
-                gran_idx=[np.uint64(999999)],
-                source_file=(["gran_idx"], [file]),
-            ),
-            attrs=dict(data_product=self.product),
+            coords={
+                "gran_idx": [np.uint64(999999)],
+                "source_file": (["gran_idx"], [file]),
+            },
+            attrs={"data_product": self.product},
         )
         return is2ds
 
@@ -740,7 +740,7 @@ class Read(EarthdataAuthMixin):
             "ATL23",
         ]:
             wanted_grouponly_set = set(wanted_groups_tiered[0])
-            wanted_groups_list = list(sorted(wanted_grouponly_set))
+            wanted_groups_list = sorted(wanted_grouponly_set)
             if len(wanted_groups_list) == 1:
                 is2ds = self._read_single_grp(file, grp_path=wanted_groups_list[0])
             else:

--- a/icepyx/tests/test_auth.py
+++ b/icepyx/tests/test_auth.py
@@ -23,9 +23,7 @@ def test_get_session(auth_instance):
 # Test that .s3login_credentials creates a dict with the correct keys
 def test_get_s3login_credentials(auth_instance):
     assert isinstance(auth_instance.s3login_credentials, dict)
-    expected_keys = set(
-        ["accessKeyId", "secretAccessKey", "sessionToken", "expiration"]
-    )
+    expected_keys = {"accessKeyId", "secretAccessKey", "sessionToken", "expiration"}
     assert set(auth_instance.s3login_credentials.keys()) == expected_keys
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ ignore-words-list = "aas,socio-economic,toi"
 
 [tool.ruff.lint]
 select = [
+  "C4",   # flake8-comprehensions
   "E",    # pycodestyle
   "F",    # pyflakes
 ]


### PR DESCRIPTION
https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4

% `ruff check --select=C4 --statistics | sort -k2`
```
1	C401	[*] unnecessary-generator-set
1	C405	[*] unnecessary-literal-set
2	C408	[*] unnecessary-collection-call
1	C413	[*] unnecessary-call-around-sorted
1	C416	[*] unnecessary-comprehension
1	C419	[*] unnecessary-comprehension-in-call
```
% `ruff check --select=C4 --fix --unsafe-fixes`
```
Found 7 errors (7 fixed, 0 remaining).
```
% `ruff rule C408`
# unnecessary-collection-call (C408)

Derived from the **flake8-comprehensions** linter.

Fix is always available.

## What it does
Checks for unnecessary `dict`, `list` or `tuple` calls that can be
rewritten as empty literals.

## Why is this bad?
It's unnecessary to call, e.g., `dict()` as opposed to using an empty
literal (`{}`). The former is slower because the name `dict` must be
looked up in the global scope in case it has been rebound.

## Examples
```python
dict()
dict(a=1, b=2)
list()
tuple()
```

Use instead:
```python
{}
{"a": 1, "b": 2}
[]
()
```

## Fix safety
This rule's fix is marked as unsafe, as it may occasionally drop comments
when rewriting the call. In most cases, though, comments will be preserved.

## Options
- `lint.flake8-comprehensions.allow-dict-calls-with-keyword-arguments`
