### PR TITLE
Add ruff rules UP for pyupgrade

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -24,7 +24,7 @@ import icepyx
 
 project = "icepyx"
 year = datetime.date.today().year
-copyright = "2019-{}, The icepyx Development Team".format(year)
+copyright = f"2019-{year}, The icepyx Development Team"
 
 # -- General configuration ---------------------------------------------------
 
@@ -140,7 +140,7 @@ class MyStyle(UnsrtStyle):
     default_sorting_style = "author_year_title"  # 'none' or 'author_year_title'
 
     def __init__(self, *args, **kwargs):
-        super(MyStyle, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
 #         self.label_style = MyLabel()

--- a/doc/sphinxext/announce.py
+++ b/doc/sphinxext/announce.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- encoding:utf-8 -*-
 """
 Script to generate contributor and pull request lists
 
@@ -71,7 +70,7 @@ A total of %d pull requests were merged for this release.
 
 def get_authors(revision_range):
     pat = "^.*\\t(.*)$"
-    lst_release, cur_release = [r.strip() for r in revision_range.split("..")]
+    lst_release, cur_release = (r.strip() for r in revision_range.split(".."))
 
     if "|" in cur_release:
         # e.g. v1.0.1|HEAD
@@ -156,7 +155,7 @@ def get_pull_requests(repo, revision_range):
 
 
 def build_components(revision_range, heading="Contributors"):
-    lst_release, cur_release = [r.strip() for r in revision_range.split("..")]
+    lst_release, cur_release = (r.strip() for r in revision_range.split(".."))
     authors = get_authors(revision_range)
 
     return {

--- a/icepyx/core/APIformatting.py
+++ b/icepyx/core/APIformatting.py
@@ -84,11 +84,11 @@ def _fmt_readable_granules(dset, **kwds):
                 # use single character wildcards "?" for date strings
                 # and ATLAS granule region number
                 if dset in ("ATL07", "ATL10", "ATL20", "ATL21"):
-                    granule_name = "{0}-??_{1}_{2}{3}??_*".format(dset, 14 * "?", t, c)
+                    granule_name = "{}-??_{}_{}{}??_*".format(dset, 14 * "?", t, c)
                 elif dset in ("ATL11",):
-                    granule_name = "{0}_{1}??_*".format(dset, t)
+                    granule_name = f"{dset}_{t}??_*"
                 else:
-                    granule_name = "{0}_{1}_{2}{3}??_*".format(dset, 14 * "?", t, c)
+                    granule_name = "{}_{}_{}{}??_*".format(dset, 14 * "?", t, c)
                 # append the granule
                 readable_granule_list.append(granule_name)
     # extend with explicitly named files (full or partial)

--- a/icepyx/core/granules.py
+++ b/icepyx/core/granules.py
@@ -498,7 +498,7 @@ class Granules(EarthdataAuthMixin):
         # (could create confusion depending on whether download was interrupted or kernel restarted)
         order_fn = ".order_restart"
         if os.path.exists(order_fn):
-            with open(order_fn, "r") as fid:
+            with open(order_fn) as fid:
                 order_dat = json.load(fid)
                 self.orderIDs = order_dat["orderIDs"]
 

--- a/icepyx/core/query.py
+++ b/icepyx/core/query.py
@@ -136,12 +136,7 @@ class GenQuery:
             self._temporal = tp.Temporal(date_range, start_time, end_time)
 
     def __str__(self):
-        str = "Extent type: {0} \nCoordinates: {1}\nDate range: ({2}, {3})".format(
-            self._spatial._ext_type,
-            self._spatial._spatial_ext,
-            self._temporal._start,
-            self._temporal._end,
-        )
+        str = f"Extent type: {self._spatial._ext_type} \nCoordinates: {self._spatial._spatial_ext}\nDate range: ({self._temporal._start}, {self._temporal._end})"
         return str
 
     # ----------------------------------------------------------------------
@@ -442,9 +437,7 @@ class Query(GenQuery, EarthdataAuthMixin):
     # Properties
 
     def __str__(self):
-        str = "Product {2} v{3}\n{0}\nDate range {1}".format(
-            self.spatial_extent, self.dates, self.product, self.product_version
-        )
+        str = f"Product {self.product} v{self.product_version}\n{self.spatial_extent}\nDate range {self.dates}"
         return str
 
     @property

--- a/icepyx/core/spatial.py
+++ b/icepyx/core/spatial.py
@@ -505,13 +505,9 @@ class Spatial:
 
     def __str__(self):
         if self._geom_file is not None:
-            return "Extent type: {0}\nSource file: {1}\nCoordinates: {2}".format(
-                self._ext_type, self._geom_file, self._spatial_ext
-            )
+            return f"Extent type: {self._ext_type}\nSource file: {self._geom_file}\nCoordinates: {self._spatial_ext}"
         else:
-            return "Extent type: {0}\nCoordinates: {1}".format(
-                self._ext_type, self._spatial_ext
-            )
+            return f"Extent type: {self._ext_type}\nCoordinates: {self._spatial_ext}"
 
     @property
     def extent(self):

--- a/icepyx/core/temporal.py
+++ b/icepyx/core/temporal.py
@@ -446,7 +446,7 @@ class Temporal:
             )
 
     def __str__(self):
-        return "Start date and time: {0}\nEnd date and time: {1}".format(
+        return "Start date and time: {}\nEnd date and time: {}".format(
             self._start.strftime("%Y-%m-%d %H:%M:%S"),
             self._end.strftime("%Y-%m-%d %H:%M:%S"),
         )

--- a/icepyx/quest/dataset_scripts/argo.py
+++ b/icepyx/quest/dataset_scripts/argo.py
@@ -56,9 +56,9 @@ class Argo(DataSet):
             df = "\n" + str(self.argodata.head())
         s = (
             "---Argo---\n"
-            "Parameters: {0}\n"
-            "Pressure range: {1}\n"
-            "Dataframe head: {2}".format(self.params, prange, df)
+            f"Parameters: {self.params}\n"
+            f"Pressure range: {prange}\n"
+            f"Dataframe head: {df}"
         )
 
         return s
@@ -115,7 +115,7 @@ class Argo(DataSet):
         coordinates_array = np.asarray(gdf.geometry[0].exterior.coords)
         x = ""
         for i in coordinates_array:
-            coord = "[{0},{1}]".format(i[0], i[1])
+            coord = f"[{i[0]},{i[1]}]"
             if x == "":
                 x = coord
             else:
@@ -228,9 +228,7 @@ class Argo(DataSet):
             for i in params:
                 assert (
                     i in valid_params
-                ), "Parameter '{0}' is not valid. Valid parameters are {1}".format(
-                    i, valid_params
-                )
+                ), f"Parameter '{i}' is not valid. Valid parameters are {valid_params}"
 
         return list(set(params))
 
@@ -308,7 +306,7 @@ class Argo(DataSet):
                 return msg
 
             else:
-                msg = "Error: Unexpected response {}".format(resp)
+                msg = f"Error: Unexpected response {resp}"
                 print(msg)
                 return msg
 
@@ -319,7 +317,7 @@ class Argo(DataSet):
         # should we be doing a set/duplicates check here??
         self.prof_ids = prof_ids
 
-        msg = "{0} valid profiles have been identified".format(len(prof_ids))
+        msg = f"{len(prof_ids)} valid profiles have been identified"
         print(msg)
         return msg
 
@@ -363,7 +361,7 @@ class Argo(DataSet):
 
         # Consider any status other than 2xx an error
         if not resp.status_code // 100 == 2:
-            return "Error: Unexpected response {}".format(resp)
+            return f"Error: Unexpected response {resp}"
         profile = resp.json()
         return profile
 
@@ -396,9 +394,7 @@ class Argo(DataSet):
             profileDf["lon"] = profile_data["geolocation"]["coordinates"][0]
             profileDf["date"] = profile_data["timestamp"]
         except KeyError as err:
-            msg = "We cannot automatically parse your profile into a dataframe due to {0}".format(
-                err
-            )
+            msg = f"We cannot automatically parse your profile into a dataframe due to {err}"
             print(msg)
             return msg
 
@@ -478,7 +474,7 @@ class Argo(DataSet):
                 profile_df = self._parse_into_df(profile_data[0])
                 merged_df = pd.concat([merged_df, profile_df], sort=False)
             except:
-                print("\tError processing profile {0}. Skipping.".format(i))
+                print(f"\tError processing profile {i}. Skipping.")
 
         # now that we have a df from this round of downloads, we can add it to any existing dataframe
         # note that if a given column has previously been added, update needs to be used to replace nans (merge will not replace the nan values)

--- a/icepyx/quest/quest.py
+++ b/icepyx/quest/quest.py
@@ -65,7 +65,7 @@ class Quest(GenQuery):
         self.datasets = {}
 
     def __str__(self):
-        str = super(Quest, self).__str__()
+        str = super().__str__()
 
         str += "\nData sets: "
 
@@ -73,7 +73,7 @@ class Quest(GenQuery):
             str += "None"
         else:
             for i in self.datasets.keys():
-                str += "{0}, ".format(i)
+                str += f"{i}, "
             str = str[:-2]  # remove last ', '
 
         return str
@@ -189,7 +189,7 @@ class Quest(GenQuery):
 
             except:
                 dataset_name = type(v).__name__
-                print("Error querying data from {0}".format(dataset_name))
+                print(f"Error querying data from {dataset_name}")
 
     # error handling? what happens if the user tries to re-download?
     def download_all(self, path="", **kwargs):
@@ -228,7 +228,7 @@ class Quest(GenQuery):
                     print(msg)
             except:
                 dataset_name = type(v).__name__
-                print("Error downloading data from {0}".format(dataset_name))
+                print(f"Error downloading data from {dataset_name}")
 
     def save_all(self, path):
         """

--- a/icepyx/tests/test_quest_argo.py
+++ b/icepyx/tests/test_quest_argo.py
@@ -38,7 +38,7 @@ def test_validate_parameters(argo_quest_instance):
     invalid_params = ["temp", "temperature_files"]
 
     ermsg = re.escape(
-        "Parameter '{0}' is not valid. Valid parameters are {1}".format(
+        "Parameter '{}' is not valid. Valid parameters are {}".format(
             "temp", reg_a._valid_params()
         )
     )
@@ -70,7 +70,7 @@ def test_param_setter_invalid_inputs(argo_quest_instance):
     assert reg_a.params == exp
 
     ermsg = re.escape(
-        "Parameter '{0}' is not valid. Valid parameters are {1}".format(
+        "Parameter '{}' is not valid. Valid parameters are {}".format(
             "temp", reg_a._valid_params()
         )
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ ignore-words-list = "aas,socio-economic,toi"
 select = [
   "E",    # pycodestyle
   "F",    # pyflakes
+  "UP",   # pyupgrade
 ]
 ignore = [
   # Line too long


### PR DESCRIPTION
https://docs.astral.sh/ruff/rules/#pyupgrade-up

% `ruff check --select=UP --statistics | sort -k2`
```
 2	UP008	[*] super-call-with-parameters
 1	UP009	[*] utf8-encoding-declaration
 1	UP015	[*] redundant-open-modes
 2	UP027	[*] unpacked-list-comprehension
19	UP030	[*] format-literals
17	UP032	[*] f-string
```
% `ruff check --select=UP --fix --unsafe-fixes`
```
Found 28 errors (21 fixed, 7 remaining).
```
% `ruff rule UP032`
# f-string (UP032)

Derived from the **pyupgrade** linter.

Fix is sometimes available.

## What it does
Checks for `str.format` calls that can be replaced with f-strings.

## Why is this bad?
f-strings are more readable and generally preferred over `str.format`
calls.

## Example
```python
"{}".format(foo)
```

Use instead:
```python
f"{foo}"
```

## References
- [Python documentation: f-strings](https://docs.python.org/3/reference/lexical_analysis.html#f-strings)

