### PR TITLE
Add ruff rules SIM to simplify Python code

### DIFF
--- a/doc/sphinxext/announce.py
+++ b/doc/sphinxext/announce.py
@@ -77,10 +77,7 @@ def get_authors(revision_range):
         # e.g. v1.0.1|HEAD
         maybe_tag, head = cur_release.split("|")
         assert head == "HEAD"
-        if maybe_tag in this_repo.tags:
-            cur_release = maybe_tag
-        else:
-            cur_release = head
+        cur_release = maybe_tag if maybe_tag in this_repo.tags else head
         revision_range = f"{lst_release}..{cur_release}"
 
     # authors, in current release and previous to current release.

--- a/icepyx/core/APIformatting.py
+++ b/icepyx/core/APIformatting.py
@@ -73,7 +73,7 @@ def _fmt_readable_granules(dset, **kwds):
     # list of readable granule names
     readable_granule_list = []
     # if querying either by 91-day orbital cycle or RGT
-    if "cycles" in kwargs.keys() or "tracks" in kwargs.keys():
+    if "cycles" in kwargs or "tracks" in kwargs:
         # default character wildcards for cycles and tracks
         kwargs.setdefault("cycles", ["??"])
         kwargs.setdefault("tracks", ["????"])
@@ -110,7 +110,7 @@ def _fmt_var_subset_list(vdict):
     """
 
     subcover = ""
-    for vn in vdict.keys():
+    for vn in vdict:
         vpaths = vdict[vn]
         for vpath in vpaths:
             subcover += "/" + vpath + ","
@@ -300,7 +300,7 @@ class Parameters:
 
         val_list = list({val for lis in self.poss_keys.values() for val in lis})
 
-        for key in self.fmted_keys.keys():
+        for key in self.fmted_keys:
             assert key in val_list, (
                 "An invalid key (" + key + ") was passed. Please remove it using `del`"
             )
@@ -317,7 +317,7 @@ class Parameters:
         ), "You cannot call this function for your parameter type"
         reqkeys = self.poss_keys[self._reqtype]
 
-        if all(keys in self.fmted_keys.keys() for keys in reqkeys):
+        if all(keys in self.fmted_keys for keys in reqkeys):
             assert all(
                 self.fmted_keys.get(key, -9999) != -9999 for key in reqkeys
             ), "One of your formatted parameters is missing a value"
@@ -337,7 +337,7 @@ class Parameters:
         spatial_keys = self.poss_keys["spatial"]
 
         # not the most robust check, but better than nothing...
-        if any(keys in self._fmted_keys.keys() for keys in spatial_keys):
+        if any(keys in self._fmted_keys for keys in spatial_keys):
             assert any(
                 self.fmted_keys.get(key, -9999) != -9999 for key in spatial_keys
             ), "One of your formatted parameters is missing a value"
@@ -410,13 +410,13 @@ class Parameters:
                 opt_keys = self.poss_keys["optional"]
 
                 for key in opt_keys:
-                    if key == "Coverage" and key in kwargs.keys():
+                    if key == "Coverage" and key in kwargs:
                         # DevGoal: make there be an option along the lines of Coverage=default, which will get the default variables for that product without the user having to input is2obj.build_wanted_wanted_var_list as their input value for using the Coverage kwarg
                         self._fmted_keys.update(
                             {key: _fmt_var_subset_list(kwargs[key])}
                         )
                     elif (key == "temporal" or key == "time") and (
-                        "start" in kwargs.keys() and "end" in kwargs.keys()
+                        "start" in kwargs and "end" in kwargs
                     ):
                         self._fmted_keys.update(
                             _fmt_temporal(kwargs["start"], kwargs["end"], key)

--- a/icepyx/core/auth.py
+++ b/icepyx/core/auth.py
@@ -107,11 +107,9 @@ class EarthdataAuthMixin:
 
         # Only generate s3login_credentials the first time credentials are accessed, or if an hour
         # has passed since the last login
-        if self._s3login_credentials is None:
-            set_s3_creds()
-        elif (datetime.datetime.now() - self._s3_initial_ts) >= datetime.timedelta(
-            hours=1
-        ):
+        if self._s3login_credentials is None or (
+            datetime.datetime.now() - self._s3_initial_ts
+        ) >= datetime.timedelta(hours=1):
             set_s3_creds()
         return self._s3login_credentials
 

--- a/icepyx/core/granules.py
+++ b/icepyx/core/granules.py
@@ -75,10 +75,9 @@ def gran_IDs(grans, ids=False, cycles=False, tracks=False, dates=False, cloud=Fa
         if cloud is True:
             try:
                 for link in gran["links"]:
-                    if link["href"].startswith("s3") and link["href"].endswith(
-                        (".h5", "nc")
-                    ):
-                        gran_s3urls.append(link["href"])
+                    href = link["href"]
+                    if href.startswith("s3") and href.endswith((".h5", "nc")):
+                        gran_s3urls.append(href)
             except KeyError:
                 pass
 

--- a/icepyx/core/query.py
+++ b/icepyx/core/query.py
@@ -126,7 +126,7 @@ class GenQuery:
         **kwargs,
     ):
         # validate & init spatial extent
-        if "xdateline" in kwargs.keys():
+        if "xdateline" in kwargs:
             self._spatial = spat.Spatial(spatial_extent, xdateline=kwargs["xdateline"])
         else:
             self._spatial = spat.Spatial(spatial_extent)
@@ -637,7 +637,7 @@ class Query(GenQuery, EarthdataAuthMixin):
         else:
             # If the user has supplied a subset list of variables, append the
             # icepyx required variables to the Coverage dict
-            if "Coverage" in kwargs.keys():
+            if "Coverage" in kwargs:
                 var_list = [
                     "orbit_info/sc_orient",
                     "orbit_info/sc_orient_time",
@@ -653,7 +653,7 @@ class Query(GenQuery, EarthdataAuthMixin):
                 ]
                 # Add any variables from var_list to Coverage that are not already included
                 for var in var_list:
-                    if var not in kwargs["Coverage"].keys():
+                    if var not in kwargs["Coverage"]:
                         kwargs["Coverage"][var.split("/")[-1]] = [var]
 
             if self._subsetparams is None:
@@ -741,9 +741,7 @@ class Query(GenQuery, EarthdataAuthMixin):
         <icepyx.core.granules.Granules at [location]>
         """
 
-        if not hasattr(self, "_granules"):
-            self._granules = Granules()
-        elif self._granules is None:
+        if not hasattr(self, "_granules") or self._granules is None:
             self._granules = Granules()
 
         return self._granules
@@ -869,7 +867,7 @@ class Query(GenQuery, EarthdataAuthMixin):
         ]
 
         try:
-            all(key in self._cust_options.keys() for key in keys)
+            all(key in self._cust_options for key in keys)
         except (AttributeError, KeyError):
             self._cust_options = is2ref._get_custom_options(
                 self.session, self.product, self._version
@@ -999,7 +997,7 @@ class Query(GenQuery, EarthdataAuthMixin):
         if self._reqparams._reqtype == "search":
             self._reqparams._reqtype = "download"
 
-        if "email" in self._reqparams.fmted_keys.keys() or email is False:
+        if "email" in self._reqparams.fmted_keys or email is False:
             self._reqparams.build_params(**self._reqparams.fmted_keys)
         elif email is True:
             user_profile = self.auth.get_user_profile()
@@ -1022,7 +1020,7 @@ class Query(GenQuery, EarthdataAuthMixin):
             self.granules
 
         # Place multiple orders, one per granule, if readable_granule_name is used.
-        if "readable_granule_name[]" in self.CMRparams.keys():
+        if "readable_granule_name[]" in self.CMRparams:
             gran_name_list = self.CMRparams["readable_granule_name[]"]
             tempCMRparams = self.CMRparams
             if len(gran_name_list) > 1:

--- a/icepyx/core/read.py
+++ b/icepyx/core/read.py
@@ -120,7 +120,7 @@ def _parse_source(data_source, glob_kwargs={}) -> list:
         # if data_source is a directory glob search the directory and assign to _filelist
         data_source = os.path.join(data_source, "*")
         filelist = glob.glob(data_source, **glob_kwargs)
-    elif isinstance(data_source, str) or isinstance(data_source, Path):
+    elif isinstance(data_source, (Path, str)):
         if data_source.startswith("s3"):
             # if the string is an s3 path put it in the _filelist without globbing
             filelist = [data_source]

--- a/icepyx/core/spatial.py
+++ b/icepyx/core/spatial.py
@@ -496,7 +496,7 @@ class Spatial:
             self._spatial_ext = [float(i) for i in arrpoly]
 
         # check for cross dateline keyword submission
-        if "xdateline" in kwarg.keys():
+        if "xdateline" in kwarg:
             self._xdateln = kwarg["xdateline"]
             assert self._xdateln in [
                 True,
@@ -542,10 +542,7 @@ class Spatial:
         """
 
         # TODO: test this
-        if hasattr(self, "_xdateln"):
-            xdateln = self._xdateln
-        else:
-            xdateln = None
+        xdateln = self._xdateln if hasattr(self, "_xdateln") else None
 
         if not hasattr(self, "_gdf_spat"):
             if self._geom_file is not None:

--- a/icepyx/core/variables.py
+++ b/icepyx/core/variables.py
@@ -84,10 +84,7 @@ class Variables(EarthdataAuthMixin):
             self._path = val.check_s3bucket(path)
 
             # Set up auth
-            if self._path.startswith("s3"):
-                auth = self.auth
-            else:
-                auth = None
+            auth = self.auth if self._path.startswith("s3") else None
             # Read the product and version from the file
             self._product = is2ref.extract_product(self._path, auth=auth)
             self._version = is2ref.extract_version(self._path, auth=auth)
@@ -111,11 +108,7 @@ class Variables(EarthdataAuthMixin):
 
     @property
     def path(self):
-        if self._path:
-            path = self._path
-        else:
-            path = None
-        return path
+        return self._path or None
 
     @property
     def product(self):
@@ -271,7 +264,7 @@ class Variables(EarthdataAuthMixin):
         for vn in varlist:
             vpath, vkey = os.path.split(vn)
             # print('path '+ vpath + ', key '+vkey)
-            if vkey not in vgrp.keys():
+            if vkey not in vgrp:
                 vgrp[vkey] = [vn]
             else:
                 vgrp[vkey].append(vn)
@@ -321,7 +314,7 @@ class Variables(EarthdataAuthMixin):
         # check if the list of variables, if specified, are available in the product
         if var_list is not None:
             for var_id in var_list:
-                if var_id not in vgrp.keys():
+                if var_id not in vgrp:
                     err_msg_varid = "Invalid variable name: " + var_id + ". "
                     err_msg_varid = err_msg_varid + "Please select from this list: "
                     err_msg_varid = err_msg_varid + ", ".join(vgrp.keys())
@@ -514,9 +507,9 @@ class Variables(EarthdataAuthMixin):
             )
 
         # update the data object variables
-        for vkey in final_vars.keys():
+        for vkey in final_vars:
             # add all matching keys and paths for new variables
-            if vkey not in self.wanted.keys():
+            if vkey not in self.wanted:
                 self.wanted[vkey] = final_vars[vkey]
             else:
                 for vpath in final_vars[vkey]:

--- a/icepyx/core/variables.py
+++ b/icepyx/core/variables.py
@@ -108,7 +108,7 @@ class Variables(EarthdataAuthMixin):
 
     @property
     def path(self):
-        return self._path or None
+        return self._path if self._path else None
 
     @property
     def product(self):

--- a/icepyx/quest/dataset_scripts/argo.py
+++ b/icepyx/quest/dataset_scripts/argo.py
@@ -45,10 +45,7 @@ class Argo(DataSet):
         self._apikey = "92259861231b55d32a9c0e4e3a93f4834fc0b6fa"
 
     def __str__(self):
-        if self.presRange is None:
-            prange = "All"
-        else:
-            prange = str(self.presRange)
+        prange = "All" if self.presRange is None else str(self.presRange)
 
         if self.argodata is None:
             df = "No data yet"
@@ -297,7 +294,7 @@ class Argo(DataSet):
         selectionProfiles = resp.json()
 
         # Consider any status other than 2xx an error
-        if not resp.status_code // 100 == 2:
+        if resp.status_code // 100 != 2:
             # check for the existence of profiles from query
             if selectionProfiles == []:
                 msg = (
@@ -362,7 +359,7 @@ class Argo(DataSet):
             print(resp.url)
 
         # Consider any status other than 2xx an error
-        if not resp.status_code // 100 == 2:
+        if resp.status_code // 100 != 2:
             return "Error: Unexpected response {}".format(resp)
         profile = resp.json()
         return profile

--- a/icepyx/quest/quest.py
+++ b/icepyx/quest/quest.py
@@ -72,7 +72,7 @@ class Quest(GenQuery):
         if not self.datasets:
             str += "None"
         else:
-            for i in self.datasets.keys():
+            for i in self.datasets:
                 str += "{0}, ".format(i)
             str = str[:-2]  # remove last ', '
 

--- a/icepyx/tests/test_Earthdata.py
+++ b/icepyx/tests/test_Earthdata.py
@@ -69,7 +69,4 @@ def earthdata_login(uid=None, pwd=None, email=None, s3token=False) -> bool:
         mock_uid = os.environ.get("EARTHDATA_USERNAME")
         mock_pwd = os.environ.get("EARTHDATA_PASSWORD")
 
-    if (uid == mock_uid) & (pwd == mock_pwd):
-        return True
-    else:
-        return False
+    return bool((uid == mock_uid) & (pwd == mock_pwd))

--- a/icepyx/tests/test_behind_NSIDC_API_login.py
+++ b/icepyx/tests/test_behind_NSIDC_API_login.py
@@ -37,8 +37,8 @@ def test_get_custom_options_output(session):
     obs = is2ref._get_custom_options(session, "ATL06", "006")
     with open("./icepyx/tests/ATL06v06_options.json") as exp_json:
         exp = json.load(exp_json)
-        assert all(keys in obs.keys() for keys in exp.keys())
-        assert all(obs[key] == exp[key] for key in exp.keys())
+        assert all(keys in obs for keys in exp)
+        assert all(obs[key] == exp[key] for key in exp)
 
 
 ########## query module ##########

--- a/icepyx/tests/test_quest.py
+++ b/icepyx/tests/test_quest.py
@@ -27,7 +27,7 @@ def test_add_is2(quest_instance):
     obs = quest_instance.datasets
 
     assert type(obs) is dict
-    assert exp_key in obs.keys()
+    assert exp_key in obs
     assert type(obs[exp_key]) is exp_type
     assert quest_instance.datasets[exp_key].product == prod
 
@@ -41,7 +41,7 @@ def test_add_argo(quest_instance):
     obs = quest_instance.datasets
 
     assert type(obs) is dict
-    assert exp_key in obs.keys()
+    assert exp_key in obs
     assert type(obs[exp_key]) is exp_type
     assert set(quest_instance.datasets[exp_key].params) == set(params)
 
@@ -54,7 +54,7 @@ def test_add_multiple_datasets(quest_instance):
     # print(quest_instance.datasets["icesat2"].product)
 
     exp_keys = ["argo", "icesat2"]
-    assert set(exp_keys) == set(quest_instance.datasets.keys())
+    assert set(exp_keys) == set(quest_instance.datasets)
 
 
 ########## ALL DATASET METHODS TESTS ##########

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ select = [
   "C4",   # flake8-comprehensions
   "E",    # pycodestyle
   "F",    # pyflakes
+  "SIM",  # flake8-simplify
 ]
 ignore = [
   # Line too long
@@ -87,6 +88,7 @@ ignore = [
   # overlong comments.
   # See: https://github.com/psf/black/issues/1713#issuecomment-1357045092
   "E501",
+  "SIM105",  # suppressible-exception
 ]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
https://docs.astral.sh/ruff/rules/#flake8-simplify-sim

% `ruff check --select=SIM --statistics`
```
26	SIM118	[*] in-dict-keys
 5	SIM105	[ ] suppressible-exception
 5	SIM108	[*] if-else-block-instead-of-if-exp
 2	SIM114	[*] if-with-same-arms
 2	SIM201	[*] negate-equal-op
 1	SIM101	[*] duplicate-isinstance-call
 1	SIM103	[*] needless-bool
```
% `ruff rule SIM118`
# in-dict-keys (SIM118)

Derived from the **flake8-simplify** linter.

Fix is always available.

## What it does
Checks for key-existence checks against `dict.keys()` calls.

## Why is this bad?
When checking for the existence of a key in a given dictionary, using
`key in dict` is more readable and efficient than `key in dict.keys()`,
while having the same semantics.

## Example
```python
key in foo.keys()
```

Use instead:
```python
key in foo
```

## Fix safety
Given `key in obj.keys()`, `obj` _could_ be a dictionary, or it could be
another type that defines a `.keys()` method. In the latter case, removing
the `.keys()` attribute could lead to a runtime error. The fix is marked
as safe when the type of `obj` is known to be a dictionary; otherwise, it
is marked as unsafe.

## References
- [Python documentation: Mapping Types](https://docs.python.org/3/library/stdtypes.html#mapping-types-dict)

[preview]: https://docs.astral.sh/ruff/preview/
