### PR TITLE
Enable currently-ignored linting rules E721, E722, F403

### DIFF
--- a/icepyx/quest/dataset_scripts/__init__.py
+++ b/icepyx/quest/dataset_scripts/__init__.py
@@ -1,1 +1,1 @@
-from .dataset import *
+from .dataset import *  # noqa: F403

--- a/icepyx/quest/dataset_scripts/argo.py
+++ b/icepyx/quest/dataset_scripts/argo.py
@@ -477,7 +477,7 @@ class Argo(DataSet):
                 profile_data = self._download_profile(i)
                 profile_df = self._parse_into_df(profile_data[0])
                 merged_df = pd.concat([merged_df, profile_df], sort=False)
-            except:
+            except Exception:
                 print("\tError processing profile {0}. Skipping.".format(i))
 
         # now that we have a df from this round of downloads, we can add it to any existing dataframe

--- a/icepyx/quest/quest.py
+++ b/icepyx/quest/quest.py
@@ -187,7 +187,7 @@ class Quest(GenQuery):
                     except KeyError:
                         v.search_data()
 
-            except:
+            except Exception:
                 dataset_name = type(v).__name__
                 print("Error querying data from {0}".format(dataset_name))
 
@@ -226,7 +226,7 @@ class Quest(GenQuery):
                     except KeyError:
                         msg = v.download()
                     print(msg)
-            except:
+            except Exception:
                 dataset_name = type(v).__name__
                 print("Error downloading data from {0}".format(dataset_name))
 

--- a/icepyx/tests/test_Earthdata.py
+++ b/icepyx/tests/test_Earthdata.py
@@ -65,7 +65,7 @@ def earthdata_login(uid=None, pwd=None, email=None, s3token=False) -> bool:
     try:
         url = "urs.earthdata.nasa.gov"
         mock_uid, _, mock_pwd = netrc.netrc(netrc).authenticators(url)
-    except:
+    except Exception:
         mock_uid = os.environ.get("EARTHDATA_USERNAME")
         mock_pwd = os.environ.get("EARTHDATA_PASSWORD")
 

--- a/icepyx/tests/test_quest.py
+++ b/icepyx/tests/test_quest.py
@@ -26,9 +26,9 @@ def test_add_is2(quest_instance):
 
     obs = quest_instance.datasets
 
-    assert type(obs) == dict
+    assert isinstance(obs, dict)
     assert exp_key in obs.keys()
-    assert type(obs[exp_key]) == exp_type
+    assert isinstance(obs[exp_key], exp_type)
     assert quest_instance.datasets[exp_key].product == prod
 
 
@@ -40,9 +40,9 @@ def test_add_argo(quest_instance):
 
     obs = quest_instance.datasets
 
-    assert type(obs) == dict
+    assert isinstance(obs, dict)
     assert exp_key in obs.keys()
-    assert type(obs[exp_key]) == exp_type
+    assert isinstance(obs[exp_key], exp_type)
     assert set(quest_instance.datasets[exp_key].params) == set(params)
 
 

--- a/icepyx/tests/test_quest.py
+++ b/icepyx/tests/test_quest.py
@@ -26,9 +26,9 @@ def test_add_is2(quest_instance):
 
     obs = quest_instance.datasets
 
-    assert isinstance(obs, dict)
+    assert type(obs) is dict
     assert exp_key in obs.keys()
-    assert isinstance(obs[exp_key], exp_type)
+    assert type(obs[exp_key]) is exp_type
     assert quest_instance.datasets[exp_key].product == prod
 
 
@@ -40,9 +40,9 @@ def test_add_argo(quest_instance):
 
     obs = quest_instance.datasets
 
-    assert isinstance(obs, dict)
+    assert type(obs) is dict
     assert exp_key in obs.keys()
-    assert isinstance(obs[exp_key], exp_type)
+    assert type(obs[exp_key]) is exp_type
     assert set(quest_instance.datasets[exp_key].params) == set(params)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,8 @@ version_file_template = 'version = "{version}"'
 local_scheme = "node-and-date"
 fallback_version = "unknown"
 
+[tool.codespell]
+ignore-words-list = "aas,socio-economic,toi"
 
 [tool.ruff]
 # DevGoal: Lint and format all Jupyter Notebooks, remove below.
@@ -70,9 +72,6 @@ extend-exclude = ["*.ipynb"]
 # [tool.ruff.format]
 # docstring-code-format = true
 # docstring-code-line-length = "dynamic"
-
-[tool.codespell]
-ignore-words-list = "aas,socio-economic,toi"
 
 [tool.ruff.lint]
 select = [
@@ -87,13 +86,6 @@ ignore = [
   # overlong comments.
   # See: https://github.com/psf/black/issues/1713#issuecomment-1357045092
   "E501",
-  # TODO: remove ignores below this line
-  # comparison syntax in tests
-  "E721",
-  # bare except
-  "E722",
-  # unable to detect undefined names
-  "F403",
 ]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
All three of these are discussed on [PEP8](https://peps.python.org/pep-0008) and should not be ignored.

E722 is https://realpython.com/the-most-diabolical-python-antipattern

```diff
[tool.ruff.lint]
ignore = [
-  # TODO: remove ignores below this line
-  # comparison syntax in tests
-  "E721",
-  # bare except
-  "E722",
-  # unable to detect undefined names
-  "F403",
]
```
