### PR TITLE
bump sangonzal/repository-traffic-action version to latest working one (fixes #596)

### DIFF
--- a/.github/workflows/traffic_action.yml
+++ b/.github/workflows/traffic_action.yml
@@ -23,7 +23,7 @@ jobs:
 
     # Calculates traffic and clones and stores in CSV file
     - name: GitHub traffic
-      uses: sangonzal/repository-traffic-action@v1
+      uses: sangonzal/repository-traffic-action@v0.1.6
       env:
         TRAFFIC_ACTION_TOKEN: ${{ secrets.TRAFFIC_ACTION_TOKEN }}
 


### PR DESCRIPTION
#596 bumped the version to an invalid version number (v1), causing the action to fail.