### PR TITLE
release v1.3.0

### DIFF
--- a/doc/source/user_guide/changelog/index.rst
+++ b/doc/source/user_guide/changelog/index.rst
@@ -7,8 +7,16 @@ This is the list of changes made to icepyx in between each release.
 Full details can be found in the `commit logs <https://github.com/icesat2py/icepyx/commits>`_.
 
 
-Latest Release (Version 1.2.0)
+Latest Release (Version 1.3.0)
 ------------------------------
+
+.. toctree::
+   :maxdepth: 2
+
+   v1.3.0
+
+Version 1.2.0
+-------------
 
 .. toctree::
    :maxdepth: 2

--- a/doc/source/user_guide/changelog/v1.3.0.rst
+++ b/doc/source/user_guide/changelog/v1.3.0.rst
@@ -8,7 +8,7 @@ including other versions of icepyx.
     This is anticipated to be the last release in v1 of icepyx.
 
     NSIDC (the NASA DAAC that hosts ICESat-2 data) is transitioning their
-    API endpoint from the on-premesis EGI system to the cloud-based Harmony services.
+    API endpoint from the on-premises EGI system to the cloud-based Harmony services.
     icepyx is being updated to access these new services; the only change users
     will experience concerns services that are no longer available (e.g. reformatting).
 

--- a/doc/source/user_guide/changelog/v1.3.0.rst
+++ b/doc/source/user_guide/changelog/v1.3.0.rst
@@ -19,12 +19,6 @@ including other versions of icepyx.
     Find more details on all these changes, including their progress, on GitHub issues and discussions.
 
 
-New Features
-~~~~~~~~~~~~
-
-- Extract constant URLs to own module (#591)
-
-
 Bug fixes
 ~~~~~~~~~
 
@@ -34,7 +28,8 @@ Bug fixes
 Deprecations
 ~~~~~~~~~~~~
 
-- None
+- Drop support for Python 3.7 and 3.8 (#608)
+- Add v1.x deprecation warning (#603)
 
 
 Maintenance
@@ -54,6 +49,7 @@ Maintenance
 - Add ruff rules SIM to simplify Python code (#572)
 - More ruff & pre-commit rules (#546)
 - Fix minor typo (#589)
+- Extract constant URLs to own module (#591)
 - Clarify some comments / docstrings (#592)
 - Migrate unit and integration tests from TravisCI to GitHub Actions (#580)
 - Reinstate test_download_granules_without_subsetting (#581)
@@ -64,6 +60,7 @@ Maintenance
 - Bump sangonzal/repository-traffic-action from 0.1.5 to 1 in the github-actions group (#596)
 - [pre-commit.ci] pre-commit autoupdate (#597)
 - bump sangonzal/repository-traffic-action version to latest working one (fixes #596) (#601)
+- Replace integration test review trigger with manual trigger (#595)
 
 
 Documentation

--- a/doc/source/user_guide/changelog/v1.3.0.rst
+++ b/doc/source/user_guide/changelog/v1.3.0.rst
@@ -1,0 +1,84 @@
+What's new in 1.3.0 (13 September 2024)
+---------------------------------------
+
+These are the changes in icepyx 1.3.0 See :ref:`release` for a full changelog
+including other versions of icepyx.
+
+.. warning::
+    This is anticipated to be the last release in v1 of icepyx.
+
+    NSIDC (the NASA DAAC that hosts ICESat-2 data) is transitioning their
+    API endpoint from the on-premesis EGI system to the cloud-based Harmony services.
+    icepyx is being updated to access these new services; the only change users
+    will experience concerns services that are no longer available (e.g. reformatting).
+
+    The developers plan to use this version change to implement additional breaking
+    changes concerning the Query module, transitioning it's functionality to use
+    the earthaccess library instead.
+
+    Find more details on all these changes, including their progress, on GitHub issues and discussions.
+
+
+New Features
+~~~~~~~~~~~~
+
+- Extract constant URLs to own module (#591)
+
+
+Bug fixes
+~~~~~~~~~
+
+- Bugfix: catch multiple types of exceptions (#560)
+
+
+Deprecations
+~~~~~~~~~~~~
+
+- None
+
+
+Maintenance
+^^^^^^^^^^^
+
+- Avoid running tests that require creds on PRs (#563)
+
+    - enables PRs from forks to pass CI tests and be merged
+
+- Skip linting and formatting Jupyter Notebooks for now (#567)
+- Keep GitHub Actions up to date with GitHub's Dependabot (#555)
+- Bump the github-actions group with 3 updates (#568)
+- Add codespell spelling/typo linter and fix errors (#556)
+- Validate pyproject.toml (#557)
+- Enable currently-ignored linting rules E721, E722, F403 (#573)
+- Add ruff rules C4 to check comprehensions (#570)
+- Add ruff rules SIM to simplify Python code (#572)
+- More ruff & pre-commit rules (#546)
+- Fix minor typo (#589)
+- Clarify some comments / docstrings (#592)
+- Migrate unit and integration tests from TravisCI to GitHub Actions (#580)
+- Reinstate test_download_granules_without_subsetting (#581)
+
+    - Ensure that granules can be ordered from NSIDC and downloaded with the `subset=False` option.
+    - Also fix a possible race condition in case the NSIDC order status is completed right at the start (e.g. when order was cached/done already).
+
+- Bump sangonzal/repository-traffic-action from 0.1.5 to 1 in the github-actions group (#596)
+- [pre-commit.ci] pre-commit autoupdate (#597)
+- bump sangonzal/repository-traffic-action version to latest working one (fixes #596) (#601)
+
+
+Documentation
+^^^^^^^^^^^^^
+
+- Update viz doc to clarify its current status (partial functionality - incompatible with OA API changes) (#540)
+- Add quickstart to README (#549)
+- docs: add cclauss as a contributor for maintenance and review (#583)
+- docs: add jrenrut as a contributor for bug, and code (#586)
+- docs: add mfisher87 as a contributor for bug, code, and 4 more (#585)
+- Tweak format and wording of contributor doc (#566)
+- [docs] traffic updates May-Aug 2024 (#606)
+
+
+Contributors
+~~~~~~~~~~~~
+
+.. contributors:: v1.2.0..v1.3.0|HEAD


### PR DESCRIPTION
Intended to be the final v1xx release of icepyx, v1.3.0 introduces a lot of maintenance upgrades, including:
- transitioning from flake8 and black to ruff for formatting and linting
- moving testing/CI from Travis to GitHub Actions