### PR TITLE
Drop support for Python 3.7 and 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "Python tools for obtaining and working with ICESat-2 data"
 license = {file = "LICENSE"}
 readme = "README.rst"
 
-requires-python = "~=3.7"
+requires-python = ">=3.9"
 dynamic = ["version", "dependencies"]
 
 authors = [
@@ -20,8 +20,6 @@ classifiers=[
   "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.7",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Since dependencies aren't resolvable with 3.7 in conda or pip (and 3.8 unresolvable with conda only), dropping support prior to the final 1.x release