### PR TITLE
add dependabot ignore for non-semantic v1 of repository-traffic-action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,6 @@ updates:
           - "*"  # Group all Actions updates into a single larger pull request
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: "sangonzal/repository-traffic-action"
+        versions: "v1"


### PR DESCRIPTION
Adds ignore to prevent recurrence of #596 with need for #601.