### PR TITLE
Remove references to UAT

### DIFF
--- a/HARMONY_MIGRATION_NOTES.md
+++ b/HARMONY_MIGRATION_NOTES.md
@@ -15,10 +15,6 @@
 Work in progress is on the `harmony` branch. This depends on the `low-hanging-refactors`
 branch being merged. A PR is open.
 
-> [!IMPORTANT]
-> Several commits establish communication with UAT instead of production. They will need
-> to be reverted once Harmony is available in prod.
-
 In addition to this work, refactoring, type checking, and type annotations have been
 added to the codebase to support the migration to Harmony.
 
@@ -28,8 +24,7 @@ added to the codebase to support the migration to Harmony.
 * Check out this amazing notebook provided by Amy Steiker and Patrick Quinn:
   <https://github.com/nasa/harmony/blob/main/docs/Harmony%20API%20introduction.ipynb>
 * Review the interactive API documentation:
-  <https://harmony.uat.earthdata.nasa.gov/docs/api/> (remember, remove UAT from URL if
-  Harmony is live with ICESat-2 products in early October 2024)
+  <https://harmony.earthdata.nasa.gov/docs/api/>
 
 
 ### Getting started replacing ECS with Harmony
@@ -94,9 +89,8 @@ The type annotations will help with this process!
     both CMR and Harmony queries without an intervening layer. E.g.
 2. Broken assumption: "We can query with only short_name and version number". Harmony
    requires a unique identifier (concept ID or DOI). E.g.:
-   <https://harmony.uat.earthdata.nasa.gov/capabilities?collectionId=C1261703129-EEDTEST>
-   (NOTE: UAT query using a collection from a test provider; we should be using
-   `NSIDC_CUAT` provider in real UAT queries and `NSIDC_CPRD` for real prod queries).
+   <https://harmony.earthdata.nasa.gov/capabilities?collectionId=C1261703129-EEDTEST>
+   .
    Since we want the user to be able to provide short_name and version, implementing the
    concept ID as a `@cached_property` on `Query` which asks CMR for the concept ID makes
    sense to me.
@@ -107,30 +101,6 @@ The type annotations will help with this process!
 * Now that we're ripping things apart and changing parameters, I think it's important to
   replace the TypedDict annotations we're using with Pydantic models. This will enable us
   to better encapsulate validation code that's currently spread around.
-
-
-## Testing with Harmony
-
-Harmony is available for testing in the UAT environment.
-
-> [!NOTE]
-> ICESat-2 products will be available in production in early October 2024. If you're
-> reading this after that time, please talk to Amy Steiker about Harmony's current
-> status before investing time setting up to test with UAT. If prod is available, test
-> with prod.
-
-We will need to interact with everything (CMR, Earthdata Login, Harmony itself) in UAT
-for icepyx to work correctly.
-
-* URLs *temporarily* modified for UAT.
-* You need a separate Earthdata Login registration for UAT
-  (<https://uat.urs.earthdata.nasa.gov/>).
-* The UAT NSIDC provider name is `NSIDC_UAT`
-  (<https://cmr.uat.earthdata.nasa.gov/search/collections.json?provider=NSIDC_CUAT>).
-* To test in UAT (i.e. access data in `NSIDC_CUAT` provider), your Earthdata Login
-  account must be on an access control list. Ask NSIDC operations for help.
-    * The code *temporarily* uses `$EDL_TOKEN` envvar to authenticate with CMR. Populate
-      this envvar with your Earthdata Login token.
 
 
 ## Integrating with other ongoing Icepyx work

--- a/icepyx/core/auth.py
+++ b/icepyx/core/auth.py
@@ -68,7 +68,7 @@ class EarthdataAuthMixin:
         """
         # Only login the first time .auth is accessed
         if self._auth is None:
-            auth = earthaccess.login(system=earthaccess.system.UAT)
+            auth = earthaccess.login()
             # check for a valid auth response
             if auth.authenticated is False:
                 raise AuthenticationError(

--- a/icepyx/core/cmr.py
+++ b/icepyx/core/cmr.py
@@ -3,18 +3,13 @@ from typing import Final
 import requests
 
 from icepyx.core.urls import COLLECTION_SEARCH_BASE_URL
-from icepyx.uat import EDL_ACCESS_TOKEN
 
-CMR_PROVIDER: Final = "NSIDC_CUAT"
-# CMR_PROVIDER: Final = "NSIDC_CPRD"
+CMR_PROVIDER: Final = "NSIDC_CPRD"
 
 
 def get_concept_id(*, product: str, version: str) -> str:
     response = requests.get(
         COLLECTION_SEARCH_BASE_URL,
-        headers={
-            "Authorization": f"Bearer {EDL_ACCESS_TOKEN}",
-        },
         params={
             "short_name": product,
             "version": version,

--- a/icepyx/core/urls.py
+++ b/icepyx/core/urls.py
@@ -1,12 +1,12 @@
 from typing import Final
 
-# TODO: Not UAT!
-CMR_BASE_URL: Final = "https://cmr.uat.earthdata.nasa.gov"
+CMR_BASE_URL: Final = "https://cmr.earthdata.nasa.gov"
 GRANULE_SEARCH_BASE_URL: Final = f"{CMR_BASE_URL}/search/granules"
 COLLECTION_SEARCH_BASE_URL: Final = f"{CMR_BASE_URL}/search/collections.json"
 
-# TODO: Not UAT!
-HARMONY_BASE_URL: Final = "https://harmony.uat.earthdata.nasa.gov"
+# TODO: the harmony base url and capabilities URL will be handled by
+# `harmony-py`: remove these constants.
+HARMONY_BASE_URL: Final = "https://harmony.earthdata.nasa.gov"
 CAPABILITIES_BASE_URL: Final = f"{HARMONY_BASE_URL}/capabilities"
 ORDER_BASE_URL: Final = f"{HARMONY_BASE_URL}/...?"
 DOWNLOAD_BASE_URL: Final = f"{HARMONY_BASE_URL}/...?"

--- a/icepyx/uat.py
+++ b/icepyx/uat.py
@@ -1,6 +1,0 @@
-import os
-from typing import Final
-
-# HACK: For testing with UAT, we need a token to authorize ourselves to see the
-#       private collections we want to test with.
-EDL_ACCESS_TOKEN: Final = os.environ["EDL_TOKEN"]


### PR DESCRIPTION
Created this PR to identify UAT-specific code that Matt added. This temporary support for UAT is no longer needed, as IS2 collections are now supported in production harmony. 