### PR TITLE
make np.datetime64 units "ns" explicitly

### DIFF
--- a/icepyx/core/read.py
+++ b/icepyx/core/read.py
@@ -49,10 +49,10 @@ def _make_np_datetime(df, keyword):
     if df[keyword].str.endswith("Z"):
         # manually remove 'Z' from datetime to allow conversion to np.datetime64 object
         # (support for timezones is deprecated and causes a seg fault)
-        df.update({keyword: df[keyword].str[:-1].astype(np.datetime64)})
+        df.update({keyword: df[keyword].str[:-1].astype("datetime64[ns]")})
 
     else:
-        df[keyword] = df[keyword].astype(np.datetime64)
+        df[keyword] = df[keyword].astype("datetime64[ns]")
 
     return df
 


### PR DESCRIPTION
makes explicit (rather than relying on default) the numpy datetime64 units as "ns" (Xarray default changed and was guessing "us" as more appropriate units instead, causing the `_make_np_datetime` docstring test (read.py) to fail).

