### PR TITLE
Switch from deprecated chartboost/ruff-action to astral-sh/ruff-action

### DIFF
--- a/.github/workflows/linter_actions.yml
+++ b/.github/workflows/linter_actions.yml
@@ -14,6 +14,4 @@ jobs:
       # Use the Ruff linter to annotate code style / best-practice issues
       # NOTE: More config provided in pyproject.toml
       - name: Lint and annotate PR
-        uses: chartboost/ruff-action@v1
-        with:
-          args: "check . --output-format github"
+        uses: astral-sh/ruff-action@v3


### PR DESCRIPTION
https://github.com/ChartBoost/ruff-action is now archived and deprecated.  Its README.md suggests that we use the [officially-supported Ruff action from Astral](https://github.com/astral-sh/ruff-action) instead.  This PR makes it so.

The default settings match the settings that were in place before this pull request.