### PR TITLE
Drop support for Python 3.9 and 3.10

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.11
 
     - name: Install dependencies
       run: python -m pip install build setuptools wheel

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install package and test dependencies
         run: |

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.12"] #NOTE: min and max Python versions supported by icepyx
+        python-version: ["3.11", "3.12"] #NOTE: min and max Python versions supported by icepyx
 
     steps:
       - uses: "actions/checkout@v4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "Python tools for obtaining and working with ICESat-2 data"
 license = {file = "LICENSE"}
 readme = "README.rst"
 
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 dynamic = ["version", "dependencies"]
 
 authors = [
@@ -20,8 +20,6 @@ classifiers=[
   "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Topic :: Scientific/Engineering",
@@ -127,7 +125,7 @@ force-sort-within-sections = true
 
 
 [tool.pyright]
-pythonVersion = "3.9"
+pythonVersion = "3.11"
 # DevGoal: "strict"
 typeCheckingMode = "standard"
 include = [

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.11"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
Set minimum required Python version to 3.11+, following [SPEC 0](https://scientific-python.org/specs/spec-0000/#support-window). Dropping support prior to icepyx v2.x release.

Merge this after #622.

Supersedes https://github.com/icesat2py/icepyx/pull/608, addresses #569