### PR TITLE
get variables list from json instead of CMR

### DIFF
--- a/icepyx/core/variables.py
+++ b/icepyx/core/variables.py
@@ -126,12 +126,21 @@ class Variables(EarthdataAuthMixin):
 
         if not hasattr(self, "_avail") or self._avail is None:
             if not hasattr(self, "path") or self.path.startswith("s3"):
-                # ToDo: add some error handling (ie for QL products or anything not in the json, and for any parsing issues with the json)
-                url = "https://raw.githubusercontent.com/icesat2py/is2_test_data/refs/heads/main/is2_test_data/data/is2variables.json"
-                response = requests.get(url, headers={"Accept": "application/json"})
-                response.raise_for_status()  # Raise HTTPError for bad responses (4xx or 5xx)
-                vars_dict = json.loads(response.content)
-                self._avail = vars_dict[self.product]
+                try:
+                    url = "https://raw.githubusercontent.com/icesat2py/is2_test_data/refs/heads/main/is2_test_data/data/is2variables.json"
+                    response = requests.get(url, headers={"Accept": "application/json"})
+                    response.raise_for_status()  # Raise HTTPError for bad responses (4xx or 5xx)
+                    vars_dict = json.loads(response.content)
+                except requests.HTTPError as e:
+                    raise e
+
+                try:
+                    self._avail = vars_dict[self.product]
+
+                except KeyError:
+                    print(
+                        f"{self.product} does not have a list of available variables."
+                    )
 
             else:
                 # If a path was given, use that file to read the variables

--- a/icepyx/core/variables.py
+++ b/icepyx/core/variables.py
@@ -1,6 +1,8 @@
+import json
 import os
 
 import numpy as np
+import requests
 
 from icepyx.core.auth import EarthdataAuthMixin
 import icepyx.core.is2ref as is2ref
@@ -124,9 +126,13 @@ class Variables(EarthdataAuthMixin):
 
         if not hasattr(self, "_avail") or self._avail is None:
             if not hasattr(self, "path") or self.path.startswith("s3"):
-                self._avail = is2ref._get_custom_options(
-                    self.session, self.product, self.version
-                )["variables"]
+                # ToDo: add some error handling (ie for QL products or anything not in the json, and for any parsing issues with the json)
+                url = "https://raw.githubusercontent.com/icesat2py/is2_test_data/refs/heads/main/is2_test_data/data/is2variables.json"
+                response = requests.get(url, headers={"Accept": "application/json"})
+                response.raise_for_status()  # Raise HTTPError for bad responses (4xx or 5xx)
+                vars_dict = json.loads(response.content)
+                self._avail = vars_dict[self.product]
+
             else:
                 # If a path was given, use that file to read the variables
                 import h5py


### PR DESCRIPTION
With the transition to Harmony and release of v007, the CMR metadata will no longer contain the list of variables. Currently, icepyx uses this metadata to quickly get the list of available variables for users in the cloud or if they just want to see/manipulate a list of them without doing so from a data file. To avoid losing this functionality, a [json containing a dictionary of the available variables](https://github.com/icesat2py/is2_test_data/blob/main/is2_test_data/data/is2variables.json) was generated in an affiliated is2_test_data repo. This PR uses that to get users variables instead of making a request to CMR.