### PR TITLE
fix issue #690

### DIFF
--- a/icepyx/core/orders.py
+++ b/icepyx/core/orders.py
@@ -57,7 +57,7 @@ class DataOrder:
     def _repr_html_(self) -> str:
         # Create a link using the <a> tag
         status = self.status()
-        link_html = f'<a target="_blank" href="{self.HARMONY_BASE_URL}{self.job_id}">View Details</a>'
+        link_html = f'<a target="_blank" href="{self.HARMONY_BASE_URL.rstrip("/")}/{self.job_id}">View Details</a>'
         # Create a self-contained HTML table with a single row
         html = f"""
         <table border="1">


### PR DESCRIPTION
- self.HARMONY_BASE_URL.rstrip("/") removes any trailing slash if it exists (to avoid // in the URL).

- Then you explicitly add a / between the base URL and the job_id.
 
- This ensures the final URL looks like:
 https://harmony.example.com/job/12345
 
 if:
 self.HARMONY_BASE_URL = "https://harmony.example.com/"
self.job_id = "abc123"

output:
<a target="_blank" href="https://harmony.example.com/abc123">View Details</a>
