### PR TITLE
fix download function to order granules if needed

### DIFF
--- a/doc/source/user_guide/documentation/classes_dev_uml.svg
+++ b/doc/source/user_guide/documentation/classes_dev_uml.svg
@@ -122,55 +122,55 @@
 <!-- icepyx.core.query.Query -->
 <g id="node16" class="node">
 <title>icepyx.core.query.Query</title>
-<polygon fill="none" stroke="black" points="1671.5,-737.5 1671.5,-1346.5 2368.5,-1346.5 2368.5,-737.5 1671.5,-737.5"/>
-<text text-anchor="start" x="1998" y="-1331.3" font-family="Times,serif" font-size="14.00">Query</text>
-<polyline fill="none" stroke="black" points="1671.5,-1323.5 2368.5,-1323.5 "/>
-<text text-anchor="start" x="1857.5" y="-1308.3" font-family="Times,serif" font-size="14.00">CMRparams : CMRParams</text>
-<text text-anchor="start" x="1857.5" y="-1293.3" font-family="Times,serif" font-size="14.00">REQUEST_RETRY_INTERVAL_SECONDS : int</text>
-<text text-anchor="start" x="1857.5" y="-1278.3" font-family="Times,serif" font-size="14.00">_CMRparams</text>
-<text text-anchor="start" x="1857.5" y="-1263.3" font-family="Times,serif" font-size="14.00">_about_product</text>
-<text text-anchor="start" x="1857.5" y="-1248.3" font-family="Times,serif" font-size="14.00">_cycles : NoneType, list</text>
-<text text-anchor="start" x="1857.5" y="-1233.3" font-family="Times,serif" font-size="14.00">_granules</text>
-<text text-anchor="start" x="1857.5" y="-1218.3" font-family="Times,serif" font-size="14.00">_prod : NoneType, str</text>
-<text text-anchor="start" x="1857.5" y="-1203.3" font-family="Times,serif" font-size="14.00">_readable_granule_name : list</text>
-<text text-anchor="start" x="1857.5" y="-1188.3" font-family="Times,serif" font-size="14.00">_temporal : Union[tp.Temporal, None]</text>
-<text text-anchor="start" x="1857.5" y="-1173.3" font-family="Times,serif" font-size="14.00">_tracks : NoneType, list</text>
-<text text-anchor="start" x="1857.5" y="-1158.3" font-family="Times,serif" font-size="14.00">_variables</text>
-<text text-anchor="start" x="1857.5" y="-1143.3" font-family="Times,serif" font-size="14.00">_version</text>
-<text text-anchor="start" x="1857.5" y="-1128.3" font-family="Times,serif" font-size="14.00">concept_id : Union[str, None]</text>
-<text text-anchor="start" x="1857.5" y="-1113.3" font-family="Times,serif" font-size="14.00">cycles</text>
-<text text-anchor="start" x="1857.5" y="-1098.3" font-family="Times,serif" font-size="14.00">granules</text>
-<text text-anchor="start" x="1857.5" y="-1083.3" font-family="Times,serif" font-size="14.00">harmony_api</text>
-<text text-anchor="start" x="1857.5" y="-1068.3" font-family="Times,serif" font-size="14.00">last_order</text>
-<text text-anchor="start" x="1857.5" y="-1053.3" font-family="Times,serif" font-size="14.00">order_vars : Union[Variables, None]</text>
-<text text-anchor="start" x="1857.5" y="-1038.3" font-family="Times,serif" font-size="14.00">product</text>
-<text text-anchor="start" x="1857.5" y="-1023.3" font-family="Times,serif" font-size="14.00">product_version</text>
-<text text-anchor="start" x="1857.5" y="-1008.3" font-family="Times,serif" font-size="14.00">tracks</text>
-<text text-anchor="start" x="1857.5" y="-993.3" font-family="Times,serif" font-size="14.00">variables : Variables</text>
-<polyline fill="none" stroke="black" points="1671.5,-985.5 2368.5,-985.5 "/>
-<text text-anchor="start" x="1679.5" y="-970.3" font-family="Times,serif" font-size="14.00">__init__(product, spatial_extent, date_range, start_time, end_time, version, cycles, tracks, auth)</text>
-<text text-anchor="start" x="1679.5" y="-955.3" font-family="Times,serif" font-size="14.00">__str__()</text>
-<text text-anchor="start" x="1679.5" y="-940.3" font-family="Times,serif" font-size="14.00">_get_concept_id(product, version): Union[str, None]</text>
-<text text-anchor="start" x="1679.5" y="-925.3" font-family="Times,serif" font-size="14.00">_get_granule_links(cloud_hosted): list[str]</text>
-<text text-anchor="start" x="1679.5" y="-910.3" font-family="Times,serif" font-size="14.00">_order_subset_granules(skip_preview: bool): str</text>
-<text text-anchor="start" x="1679.5" y="-895.3" font-family="Times,serif" font-size="14.00">_order_whole_granules(cloud_hosted): list[str]</text>
-<text text-anchor="start" x="1679.5" y="-880.3" font-family="Times,serif" font-size="14.00">avail_granules(ids, cycles, tracks, cloud)</text>
-<text text-anchor="start" x="1679.5" y="-865.3" font-family="Times,serif" font-size="14.00">download_granules(path: Path, overwrite: bool): Union[list[str], None]</text>
-<text text-anchor="start" x="1679.5" y="-850.3" font-family="Times,serif" font-size="14.00">latest_version()</text>
-<text text-anchor="start" x="1679.5" y="-835.3" font-family="Times,serif" font-size="14.00">order_granules(subset: bool, skip_preview: bool): DataOrder</text>
-<text text-anchor="start" x="1679.5" y="-820.3" font-family="Times,serif" font-size="14.00">product_all_info()</text>
-<text text-anchor="start" x="1679.5" y="-805.3" font-family="Times,serif" font-size="14.00">product_summary_info()</text>
-<text text-anchor="start" x="1679.5" y="-790.3" font-family="Times,serif" font-size="14.00">show_custom_options(): Dict[str, Any]</text>
-<text text-anchor="start" x="1679.5" y="-775.3" font-family="Times,serif" font-size="14.00">skip_preview()</text>
-<text text-anchor="start" x="1679.5" y="-760.3" font-family="Times,serif" font-size="14.00">visualize_elevation()</text>
-<text text-anchor="start" x="1679.5" y="-745.3" font-family="Times,serif" font-size="14.00">visualize_spatial_extent()</text>
+<polygon fill="none" stroke="black" points="1657.5,-737.5 1657.5,-1346.5 2410.5,-1346.5 2410.5,-737.5 1657.5,-737.5"/>
+<text text-anchor="start" x="2012" y="-1331.3" font-family="Times,serif" font-size="14.00">Query</text>
+<polyline fill="none" stroke="black" points="1657.5,-1323.5 2410.5,-1323.5 "/>
+<text text-anchor="start" x="1871.5" y="-1308.3" font-family="Times,serif" font-size="14.00">CMRparams : CMRParams</text>
+<text text-anchor="start" x="1871.5" y="-1293.3" font-family="Times,serif" font-size="14.00">REQUEST_RETRY_INTERVAL_SECONDS : int</text>
+<text text-anchor="start" x="1871.5" y="-1278.3" font-family="Times,serif" font-size="14.00">_CMRparams</text>
+<text text-anchor="start" x="1871.5" y="-1263.3" font-family="Times,serif" font-size="14.00">_about_product</text>
+<text text-anchor="start" x="1871.5" y="-1248.3" font-family="Times,serif" font-size="14.00">_cycles : NoneType, list</text>
+<text text-anchor="start" x="1871.5" y="-1233.3" font-family="Times,serif" font-size="14.00">_granules</text>
+<text text-anchor="start" x="1871.5" y="-1218.3" font-family="Times,serif" font-size="14.00">_prod : NoneType, str</text>
+<text text-anchor="start" x="1871.5" y="-1203.3" font-family="Times,serif" font-size="14.00">_readable_granule_name : list</text>
+<text text-anchor="start" x="1871.5" y="-1188.3" font-family="Times,serif" font-size="14.00">_temporal : Union[tp.Temporal, None]</text>
+<text text-anchor="start" x="1871.5" y="-1173.3" font-family="Times,serif" font-size="14.00">_tracks : NoneType, list</text>
+<text text-anchor="start" x="1871.5" y="-1158.3" font-family="Times,serif" font-size="14.00">_variables</text>
+<text text-anchor="start" x="1871.5" y="-1143.3" font-family="Times,serif" font-size="14.00">_version</text>
+<text text-anchor="start" x="1871.5" y="-1128.3" font-family="Times,serif" font-size="14.00">concept_id : Union[str, None]</text>
+<text text-anchor="start" x="1871.5" y="-1113.3" font-family="Times,serif" font-size="14.00">cycles</text>
+<text text-anchor="start" x="1871.5" y="-1098.3" font-family="Times,serif" font-size="14.00">granules</text>
+<text text-anchor="start" x="1871.5" y="-1083.3" font-family="Times,serif" font-size="14.00">harmony_api</text>
+<text text-anchor="start" x="1871.5" y="-1068.3" font-family="Times,serif" font-size="14.00">last_order</text>
+<text text-anchor="start" x="1871.5" y="-1053.3" font-family="Times,serif" font-size="14.00">order_vars : Union[Variables, None]</text>
+<text text-anchor="start" x="1871.5" y="-1038.3" font-family="Times,serif" font-size="14.00">product</text>
+<text text-anchor="start" x="1871.5" y="-1023.3" font-family="Times,serif" font-size="14.00">product_version</text>
+<text text-anchor="start" x="1871.5" y="-1008.3" font-family="Times,serif" font-size="14.00">tracks</text>
+<text text-anchor="start" x="1871.5" y="-993.3" font-family="Times,serif" font-size="14.00">variables : Variables</text>
+<polyline fill="none" stroke="black" points="1657.5,-985.5 2410.5,-985.5 "/>
+<text text-anchor="start" x="1665.5" y="-970.3" font-family="Times,serif" font-size="14.00">__init__(product, spatial_extent, date_range, start_time, end_time, version, cycles, tracks, auth)</text>
+<text text-anchor="start" x="1665.5" y="-955.3" font-family="Times,serif" font-size="14.00">__str__()</text>
+<text text-anchor="start" x="1665.5" y="-940.3" font-family="Times,serif" font-size="14.00">_get_concept_id(product, version): Union[str, None]</text>
+<text text-anchor="start" x="1665.5" y="-925.3" font-family="Times,serif" font-size="14.00">_get_granule_links(cloud_hosted): list[str]</text>
+<text text-anchor="start" x="1665.5" y="-910.3" font-family="Times,serif" font-size="14.00">_order_subset_granules(skip_preview: bool): str</text>
+<text text-anchor="start" x="1665.5" y="-895.3" font-family="Times,serif" font-size="14.00">_order_whole_granules(cloud_hosted): list[str]</text>
+<text text-anchor="start" x="1665.5" y="-880.3" font-family="Times,serif" font-size="14.00">avail_granules(ids, cycles, tracks, cloud)</text>
+<text text-anchor="start" x="1665.5" y="-865.3" font-family="Times,serif" font-size="14.00">download_granules(path: Path, overwrite: bool, subset: bool, skip_preview: bool): Union[list[str], None]</text>
+<text text-anchor="start" x="1665.5" y="-850.3" font-family="Times,serif" font-size="14.00">latest_version()</text>
+<text text-anchor="start" x="1665.5" y="-835.3" font-family="Times,serif" font-size="14.00">order_granules(subset: bool, skip_preview: bool): DataOrder</text>
+<text text-anchor="start" x="1665.5" y="-820.3" font-family="Times,serif" font-size="14.00">product_all_info()</text>
+<text text-anchor="start" x="1665.5" y="-805.3" font-family="Times,serif" font-size="14.00">product_summary_info()</text>
+<text text-anchor="start" x="1665.5" y="-790.3" font-family="Times,serif" font-size="14.00">show_custom_options(): Dict[str, Any]</text>
+<text text-anchor="start" x="1665.5" y="-775.3" font-family="Times,serif" font-size="14.00">skip_preview()</text>
+<text text-anchor="start" x="1665.5" y="-760.3" font-family="Times,serif" font-size="14.00">visualize_elevation()</text>
+<text text-anchor="start" x="1665.5" y="-745.3" font-family="Times,serif" font-size="14.00">visualize_spatial_extent()</text>
 </g>
 <!-- icepyx.core.orders.DataOrder&#45;&gt;icepyx.core.query.Query -->
 <g id="edge15" class="edge">
 <title>icepyx.core.orders.DataOrder&#45;&gt;icepyx.core.query.Query</title>
-<path fill="none" stroke="black" d="M2985.8,-670.54C2969.15,-676.32 2952.48,-681.55 2936,-686 2699.04,-750 2609.84,-643.79 2379.98,-735.95"/>
-<polygon fill="black" stroke="black" points="2379.68,-736.08 2375.65,-742.06 2368.58,-740.64 2372.6,-734.66 2379.68,-736.08"/>
-<text text-anchor="middle" x="2880.5" y="-707.8" font-family="Times,serif" font-size="14.00" fill="green">last_order</text>
+<path fill="none" stroke="black" d="M2985.3,-670.55C2968.82,-676.31 2952.31,-681.53 2936,-686 2717.12,-745.98 2635.92,-653.89 2422,-735.98"/>
+<polygon fill="black" stroke="black" points="2421.88,-736.03 2417.77,-741.95 2410.72,-740.42 2414.84,-734.5 2421.88,-736.03"/>
+<text text-anchor="middle" x="2875.5" y="-707.8" font-family="Times,serif" font-size="14.00" fill="green">last_order</text>
 </g>
 <!-- icepyx.core.exceptions.DeprecationError -->
 <g id="node7" class="node">
@@ -225,20 +225,20 @@
 <!-- icepyx.core.query.GenQuery -->
 <g id="node10" class="node">
 <title>icepyx.core.query.GenQuery</title>
-<polygon fill="none" stroke="black" points="2667,-1398.5 2667,-1587.5 3091,-1587.5 3091,-1398.5 2667,-1398.5"/>
-<text text-anchor="start" x="2842.5" y="-1572.3" font-family="Times,serif" font-size="14.00">GenQuery</text>
-<polyline fill="none" stroke="black" points="2667,-1564.5 3091,-1564.5 "/>
-<text text-anchor="start" x="2739" y="-1549.3" font-family="Times,serif" font-size="14.00">_spatial</text>
-<text text-anchor="start" x="2739" y="-1534.3" font-family="Times,serif" font-size="14.00">_temporal</text>
-<text text-anchor="start" x="2739" y="-1519.3" font-family="Times,serif" font-size="14.00">dates : list[str]</text>
-<text text-anchor="start" x="2739" y="-1504.3" font-family="Times,serif" font-size="14.00">end_time : Union[list[str], str]</text>
-<text text-anchor="start" x="2739" y="-1489.3" font-family="Times,serif" font-size="14.00">spatial</text>
-<text text-anchor="start" x="2739" y="-1474.3" font-family="Times,serif" font-size="14.00">spatial_extent</text>
-<text text-anchor="start" x="2739" y="-1459.3" font-family="Times,serif" font-size="14.00">start_time : Union[list[str], str]</text>
-<text text-anchor="start" x="2739" y="-1444.3" font-family="Times,serif" font-size="14.00">temporal : Union[tp.Temporal, list[str]]</text>
-<polyline fill="none" stroke="black" points="2667,-1436.5 3091,-1436.5 "/>
-<text text-anchor="start" x="2675" y="-1421.3" font-family="Times,serif" font-size="14.00">__init__(spatial_extent, date_range, start_time, end_time)</text>
-<text text-anchor="start" x="2675" y="-1406.3" font-family="Times,serif" font-size="14.00">__str__()</text>
+<polygon fill="none" stroke="black" points="2709,-1398.5 2709,-1587.5 3133,-1587.5 3133,-1398.5 2709,-1398.5"/>
+<text text-anchor="start" x="2884.5" y="-1572.3" font-family="Times,serif" font-size="14.00">GenQuery</text>
+<polyline fill="none" stroke="black" points="2709,-1564.5 3133,-1564.5 "/>
+<text text-anchor="start" x="2781" y="-1549.3" font-family="Times,serif" font-size="14.00">_spatial</text>
+<text text-anchor="start" x="2781" y="-1534.3" font-family="Times,serif" font-size="14.00">_temporal</text>
+<text text-anchor="start" x="2781" y="-1519.3" font-family="Times,serif" font-size="14.00">dates : list[str]</text>
+<text text-anchor="start" x="2781" y="-1504.3" font-family="Times,serif" font-size="14.00">end_time : Union[list[str], str]</text>
+<text text-anchor="start" x="2781" y="-1489.3" font-family="Times,serif" font-size="14.00">spatial</text>
+<text text-anchor="start" x="2781" y="-1474.3" font-family="Times,serif" font-size="14.00">spatial_extent</text>
+<text text-anchor="start" x="2781" y="-1459.3" font-family="Times,serif" font-size="14.00">start_time : Union[list[str], str]</text>
+<text text-anchor="start" x="2781" y="-1444.3" font-family="Times,serif" font-size="14.00">temporal : Union[tp.Temporal, list[str]]</text>
+<polyline fill="none" stroke="black" points="2709,-1436.5 3133,-1436.5 "/>
+<text text-anchor="start" x="2717" y="-1421.3" font-family="Times,serif" font-size="14.00">__init__(spatial_extent, date_range, start_time, end_time)</text>
+<text text-anchor="start" x="2717" y="-1406.3" font-family="Times,serif" font-size="14.00">__str__()</text>
 </g>
 <!-- icepyx.core.granules.Granules -->
 <g id="node11" class="node">
@@ -269,8 +269,8 @@
 <!-- icepyx.core.granules.Granules&#45;&gt;icepyx.core.query.Query -->
 <g id="edge13" class="edge">
 <title>icepyx.core.granules.Granules&#45;&gt;icepyx.core.query.Query</title>
-<path fill="none" stroke="black" d="M1366.73,-219.73C1354.61,-338.55 1333.26,-610.42 1382,-686 1392.13,-701.7 1403.4,-695.42 1420,-704 1498.59,-744.62 1581.92,-789.94 1660.67,-833.84"/>
-<polygon fill="black" stroke="black" points="1660.77,-833.9 1667.96,-833.33 1671.25,-839.75 1664.06,-840.31 1660.77,-833.9"/>
+<path fill="none" stroke="black" d="M1366.73,-219.73C1354.61,-338.55 1333.26,-610.42 1382,-686 1392.13,-701.7 1403.36,-695.5 1420,-704 1493.67,-741.62 1571.55,-783.05 1646.19,-823.6"/>
+<polygon fill="black" stroke="black" points="1646.64,-823.84 1653.82,-823.19 1657.18,-829.58 1650,-830.22 1646.64,-823.84"/>
 <text text-anchor="middle" x="1417" y="-527.3" font-family="Times,serif" font-size="14.00" fill="green">_granules</text>
 </g>
 <!-- icepyx.core.harmony.HarmonyApi -->
@@ -297,15 +297,15 @@
 <!-- icepyx.core.harmony.HarmonyApi&#45;&gt;icepyx.core.auth.EarthdataAuthMixin -->
 <g id="edge4" class="edge">
 <title>icepyx.core.harmony.HarmonyApi&#45;&gt;icepyx.core.auth.EarthdataAuthMixin</title>
-<path fill="none" stroke="black" d="M1788.55,-648.11C1742.47,-672.5 1698.89,-701.82 1662,-737 1611.08,-785.55 1442.24,-1204.12 1366.43,-1396.28"/>
-<polygon fill="none" stroke="black" points="1363.08,-1395.23 1362.67,-1405.82 1369.59,-1397.8 1363.08,-1395.23"/>
+<path fill="none" stroke="black" d="M1773.97,-648.12C1728.03,-672.46 1684.7,-701.76 1648,-737 1597.6,-785.4 1436.72,-1204.05 1364.59,-1396.26"/>
+<polygon fill="none" stroke="black" points="1361.25,-1395.2 1361.01,-1405.79 1367.8,-1397.66 1361.25,-1395.2"/>
 </g>
 <!-- icepyx.core.harmony.HarmonyApi&#45;&gt;icepyx.core.query.Query -->
 <g id="edge14" class="edge">
 <title>icepyx.core.harmony.HarmonyApi&#45;&gt;icepyx.core.query.Query</title>
-<path fill="none" stroke="black" d="M2154.3,-648.14C2146.08,-672.18 2137.05,-698.6 2127.68,-726.01"/>
-<polygon fill="black" stroke="black" points="2127.67,-726.04 2129.51,-733.01 2123.79,-737.39 2121.94,-730.42 2127.67,-726.04"/>
-<text text-anchor="middle" x="2179" y="-707.8" font-family="Times,serif" font-size="14.00" fill="green">harmony_api</text>
+<path fill="none" stroke="black" d="M2157.49,-648.14C2149.97,-672.08 2141.7,-698.36 2133.13,-725.64"/>
+<polygon fill="black" stroke="black" points="2133.04,-725.94 2135.05,-732.87 2129.44,-737.39 2127.42,-730.47 2133.04,-725.94"/>
+<text text-anchor="middle" x="2184" y="-707.8" font-family="Times,serif" font-size="14.00" fill="green">harmony_api</text>
 </g>
 <!-- icepyx.core.harmony.HarmonyTemporal -->
 <g id="node13" class="node">
@@ -366,43 +366,43 @@
 <!-- icepyx.core.APIformatting.Parameters&#45;&gt;icepyx.core.query.Query -->
 <g id="edge11" class="edge">
 <title>icepyx.core.APIformatting.Parameters&#45;&gt;icepyx.core.query.Query</title>
-<path fill="none" stroke="black" d="M3760.86,-625.62C3709.32,-649.6 3651.64,-672.43 3596,-686 3304.2,-757.19 3221.11,-706.7 2921,-719 2863.46,-721.36 2473.44,-715.76 2380.45,-736.89"/>
-<polygon fill="black" stroke="black" points="2380.29,-736.94 2375.64,-742.45 2368.76,-740.29 2373.41,-734.77 2380.29,-736.94"/>
-<text text-anchor="middle" x="3548" y="-707.8" font-family="Times,serif" font-size="14.00" fill="green">_CMRparams</text>
+<path fill="none" stroke="black" d="M3760.86,-625.63C3709.32,-649.61 3651.64,-672.44 3596,-686 3302.03,-757.67 3218.31,-706.19 2916,-719 2863.59,-721.22 2509.6,-718.26 2422.26,-736.98"/>
+<polygon fill="black" stroke="black" points="2422.19,-737 2417.47,-742.44 2410.62,-740.17 2415.35,-734.73 2422.19,-737"/>
+<text text-anchor="middle" x="3547" y="-707.8" font-family="Times,serif" font-size="14.00" fill="green">_CMRparams</text>
 </g>
 <!-- icepyx.core.query.Query&#45;&gt;icepyx.core.auth.EarthdataAuthMixin -->
 <g id="edge5" class="edge">
 <title>icepyx.core.query.Query&#45;&gt;icepyx.core.auth.EarthdataAuthMixin</title>
-<path fill="none" stroke="black" d="M1671.46,-1269.47C1600.17,-1315.8 1529.05,-1362.01 1470.25,-1400.22"/>
-<polygon fill="none" stroke="black" points="1468.14,-1397.41 1461.66,-1405.8 1471.96,-1403.28 1468.14,-1397.41"/>
+<path fill="none" stroke="black" d="M1657.25,-1282.95C1590.83,-1325.25 1525.56,-1366.81 1470.94,-1401.6"/>
+<polygon fill="none" stroke="black" points="1468.82,-1398.8 1462.27,-1407.12 1472.58,-1404.7 1468.82,-1398.8"/>
 </g>
 <!-- icepyx.core.query.Query&#45;&gt;icepyx.core.query.GenQuery -->
 <g id="edge6" class="edge">
 <title>icepyx.core.query.Query&#45;&gt;icepyx.core.query.GenQuery</title>
-<path fill="none" stroke="black" d="M2368.67,-1342.45C2371.45,-1343.99 2374.22,-1345.51 2377,-1347 2463.54,-1393.52 2566.7,-1426.63 2656.93,-1449.35"/>
-<polygon fill="none" stroke="black" points="2656.2,-1452.78 2666.75,-1451.8 2657.89,-1445.98 2656.2,-1452.78"/>
+<path fill="none" stroke="black" d="M2410.76,-1342.7C2413.51,-1344.16 2416.25,-1345.59 2419,-1347 2506.19,-1391.81 2609.22,-1424.63 2699.18,-1447.59"/>
+<polygon fill="none" stroke="black" points="2698.4,-1451.01 2708.96,-1450.07 2700.12,-1444.22 2698.4,-1451.01"/>
 </g>
 <!-- icepyx.quest.quest.Quest -->
 <g id="node18" class="node">
 <title>icepyx.quest.quest.Quest</title>
-<polygon fill="none" stroke="black" points="2386.5,-962.5 2386.5,-1121.5 2961.5,-1121.5 2961.5,-962.5 2386.5,-962.5"/>
-<text text-anchor="start" x="2652.5" y="-1106.3" font-family="Times,serif" font-size="14.00">Quest</text>
-<polyline fill="none" stroke="black" points="2386.5,-1098.5 2961.5,-1098.5 "/>
-<text text-anchor="start" x="2623" y="-1083.3" font-family="Times,serif" font-size="14.00">datasets : dict</text>
-<polyline fill="none" stroke="black" points="2386.5,-1075.5 2961.5,-1075.5 "/>
-<text text-anchor="start" x="2394.5" y="-1060.3" font-family="Times,serif" font-size="14.00">__init__(spatial_extent, date_range, start_time, end_time, proj)</text>
-<text text-anchor="start" x="2394.5" y="-1045.3" font-family="Times,serif" font-size="14.00">__str__()</text>
-<text text-anchor="start" x="2394.5" y="-1030.3" font-family="Times,serif" font-size="14.00">add_argo(params, presRange): None</text>
-<text text-anchor="start" x="2394.5" y="-1015.3" font-family="Times,serif" font-size="14.00">add_icesat2(product, start_time, end_time, version, cycles, tracks, files): None</text>
-<text text-anchor="start" x="2394.5" y="-1000.3" font-family="Times,serif" font-size="14.00">download_all(path)</text>
-<text text-anchor="start" x="2394.5" y="-985.3" font-family="Times,serif" font-size="14.00">save_all(path)</text>
-<text text-anchor="start" x="2394.5" y="-970.3" font-family="Times,serif" font-size="14.00">search_all()</text>
+<polygon fill="none" stroke="black" points="2428.5,-962.5 2428.5,-1121.5 3003.5,-1121.5 3003.5,-962.5 2428.5,-962.5"/>
+<text text-anchor="start" x="2694.5" y="-1106.3" font-family="Times,serif" font-size="14.00">Quest</text>
+<polyline fill="none" stroke="black" points="2428.5,-1098.5 3003.5,-1098.5 "/>
+<text text-anchor="start" x="2665" y="-1083.3" font-family="Times,serif" font-size="14.00">datasets : dict</text>
+<polyline fill="none" stroke="black" points="2428.5,-1075.5 3003.5,-1075.5 "/>
+<text text-anchor="start" x="2436.5" y="-1060.3" font-family="Times,serif" font-size="14.00">__init__(spatial_extent, date_range, start_time, end_time, proj)</text>
+<text text-anchor="start" x="2436.5" y="-1045.3" font-family="Times,serif" font-size="14.00">__str__()</text>
+<text text-anchor="start" x="2436.5" y="-1030.3" font-family="Times,serif" font-size="14.00">add_argo(params, presRange): None</text>
+<text text-anchor="start" x="2436.5" y="-1015.3" font-family="Times,serif" font-size="14.00">add_icesat2(product, start_time, end_time, version, cycles, tracks, files): None</text>
+<text text-anchor="start" x="2436.5" y="-1000.3" font-family="Times,serif" font-size="14.00">download_all(path)</text>
+<text text-anchor="start" x="2436.5" y="-985.3" font-family="Times,serif" font-size="14.00">save_all(path)</text>
+<text text-anchor="start" x="2436.5" y="-970.3" font-family="Times,serif" font-size="14.00">search_all()</text>
 </g>
 <!-- icepyx.quest.quest.Quest&#45;&gt;icepyx.core.query.GenQuery -->
 <g id="edge10" class="edge">
 <title>icepyx.quest.quest.Quest&#45;&gt;icepyx.core.query.GenQuery</title>
-<path fill="none" stroke="black" d="M2709.94,-1121.72C2743.83,-1195.95 2794.82,-1307.63 2831.94,-1388.93"/>
-<polygon fill="none" stroke="black" points="2828.83,-1390.55 2836.17,-1398.19 2835.2,-1387.64 2828.83,-1390.55"/>
+<path fill="none" stroke="black" d="M2751.94,-1121.72C2785.83,-1195.95 2836.82,-1307.63 2873.94,-1388.93"/>
+<polygon fill="none" stroke="black" points="2870.83,-1390.55 2878.17,-1398.19 2877.2,-1387.64 2870.83,-1390.55"/>
 </g>
 <!-- icepyx.core.read.Read -->
 <g id="node19" class="node">
@@ -436,51 +436,51 @@
 <!-- icepyx.core.spatial.Spatial -->
 <g id="node20" class="node">
 <title>icepyx.core.spatial.Spatial</title>
-<polygon fill="none" stroke="black" points="2980,-925 2980,-1159 3186,-1159 3186,-925 2980,-925"/>
-<text text-anchor="start" x="3057.5" y="-1143.8" font-family="Times,serif" font-size="14.00">Spatial</text>
-<polyline fill="none" stroke="black" points="2980,-1136 3186,-1136 "/>
-<text text-anchor="start" x="2988" y="-1120.8" font-family="Times,serif" font-size="14.00">_ext_type : str</text>
-<text text-anchor="start" x="2988" y="-1105.8" font-family="Times,serif" font-size="14.00">_gdf_spat : GeoDataFrame</text>
-<text text-anchor="start" x="2988" y="-1090.8" font-family="Times,serif" font-size="14.00">_geom_file : NoneType</text>
-<text text-anchor="start" x="2988" y="-1075.8" font-family="Times,serif" font-size="14.00">_spatial_ext</text>
-<text text-anchor="start" x="2988" y="-1060.8" font-family="Times,serif" font-size="14.00">_xdateln</text>
-<text text-anchor="start" x="2988" y="-1045.8" font-family="Times,serif" font-size="14.00">extent</text>
-<text text-anchor="start" x="2988" y="-1030.8" font-family="Times,serif" font-size="14.00">extent_as_gdf</text>
-<text text-anchor="start" x="2988" y="-1015.8" font-family="Times,serif" font-size="14.00">extent_file</text>
-<text text-anchor="start" x="2988" y="-1000.8" font-family="Times,serif" font-size="14.00">extent_type</text>
-<polyline fill="none" stroke="black" points="2980,-993 3186,-993 "/>
-<text text-anchor="start" x="3001.5" y="-977.8" font-family="Times,serif" font-size="14.00">__init__(spatial_extent)</text>
-<text text-anchor="start" x="3001.5" y="-962.8" font-family="Times,serif" font-size="14.00">__str__()</text>
-<text text-anchor="start" x="3001.5" y="-947.8" font-family="Times,serif" font-size="14.00">fmt_for_CMR()</text>
-<text text-anchor="start" x="3001.5" y="-932.8" font-family="Times,serif" font-size="14.00">fmt_for_EGI()</text>
+<polygon fill="none" stroke="black" points="3022,-925 3022,-1159 3228,-1159 3228,-925 3022,-925"/>
+<text text-anchor="start" x="3099.5" y="-1143.8" font-family="Times,serif" font-size="14.00">Spatial</text>
+<polyline fill="none" stroke="black" points="3022,-1136 3228,-1136 "/>
+<text text-anchor="start" x="3030" y="-1120.8" font-family="Times,serif" font-size="14.00">_ext_type : str</text>
+<text text-anchor="start" x="3030" y="-1105.8" font-family="Times,serif" font-size="14.00">_gdf_spat : GeoDataFrame</text>
+<text text-anchor="start" x="3030" y="-1090.8" font-family="Times,serif" font-size="14.00">_geom_file : NoneType</text>
+<text text-anchor="start" x="3030" y="-1075.8" font-family="Times,serif" font-size="14.00">_spatial_ext</text>
+<text text-anchor="start" x="3030" y="-1060.8" font-family="Times,serif" font-size="14.00">_xdateln</text>
+<text text-anchor="start" x="3030" y="-1045.8" font-family="Times,serif" font-size="14.00">extent</text>
+<text text-anchor="start" x="3030" y="-1030.8" font-family="Times,serif" font-size="14.00">extent_as_gdf</text>
+<text text-anchor="start" x="3030" y="-1015.8" font-family="Times,serif" font-size="14.00">extent_file</text>
+<text text-anchor="start" x="3030" y="-1000.8" font-family="Times,serif" font-size="14.00">extent_type</text>
+<polyline fill="none" stroke="black" points="3022,-993 3228,-993 "/>
+<text text-anchor="start" x="3043.5" y="-977.8" font-family="Times,serif" font-size="14.00">__init__(spatial_extent)</text>
+<text text-anchor="start" x="3043.5" y="-962.8" font-family="Times,serif" font-size="14.00">__str__()</text>
+<text text-anchor="start" x="3043.5" y="-947.8" font-family="Times,serif" font-size="14.00">fmt_for_CMR()</text>
+<text text-anchor="start" x="3043.5" y="-932.8" font-family="Times,serif" font-size="14.00">fmt_for_EGI()</text>
 </g>
 <!-- icepyx.core.spatial.Spatial&#45;&gt;icepyx.core.query.GenQuery -->
 <g id="edge16" class="edge">
 <title>icepyx.core.spatial.Spatial&#45;&gt;icepyx.core.query.GenQuery</title>
-<path fill="none" stroke="black" d="M3046.14,-1159.01C3026.25,-1216.7 2999.7,-1286.78 2970,-1347 2963.3,-1360.59 2955.65,-1374.53 2947.71,-1388.12"/>
-<polygon fill="black" stroke="black" points="2947.71,-1388.12 2948.09,-1395.32 2941.58,-1398.44 2941.21,-1391.24 2947.71,-1388.12"/>
-<text text-anchor="middle" x="2987.5" y="-1368.8" font-family="Times,serif" font-size="14.00" fill="green">_spatial</text>
+<path fill="none" stroke="black" d="M3088.14,-1159.01C3068.25,-1216.7 3041.7,-1286.78 3012,-1347 3005.3,-1360.59 2997.65,-1374.53 2989.71,-1388.12"/>
+<polygon fill="black" stroke="black" points="2989.71,-1388.12 2990.09,-1395.32 2983.58,-1398.44 2983.21,-1391.24 2989.71,-1388.12"/>
+<text text-anchor="middle" x="3029.5" y="-1368.8" font-family="Times,serif" font-size="14.00" fill="green">_spatial</text>
 </g>
 <!-- icepyx.core.temporal.Temporal -->
 <g id="node21" class="node">
 <title>icepyx.core.temporal.Temporal</title>
-<polygon fill="none" stroke="black" points="3204,-977.5 3204,-1106.5 4016,-1106.5 4016,-977.5 3204,-977.5"/>
-<text text-anchor="start" x="3576.5" y="-1091.3" font-family="Times,serif" font-size="14.00">Temporal</text>
-<polyline fill="none" stroke="black" points="3204,-1083.5 4016,-1083.5 "/>
-<text text-anchor="start" x="3544" y="-1068.3" font-family="Times,serif" font-size="14.00">_end : datetime</text>
-<text text-anchor="start" x="3544" y="-1053.3" font-family="Times,serif" font-size="14.00">_start : datetime</text>
-<text text-anchor="start" x="3544" y="-1038.3" font-family="Times,serif" font-size="14.00">end : dt.datetime</text>
-<text text-anchor="start" x="3544" y="-1023.3" font-family="Times,serif" font-size="14.00">start : dt.datetime</text>
-<polyline fill="none" stroke="black" points="3204,-1015.5 4016,-1015.5 "/>
-<text text-anchor="start" x="3212" y="-1000.3" font-family="Times,serif" font-size="14.00">__init__(date_range: Union[list, dict], start_time: Union[str, dt.time, None], end_time: Union[str, dt.time, None])</text>
-<text text-anchor="start" x="3212" y="-985.3" font-family="Times,serif" font-size="14.00">__str__(): str</text>
+<polygon fill="none" stroke="black" points="3246,-977.5 3246,-1106.5 4058,-1106.5 4058,-977.5 3246,-977.5"/>
+<text text-anchor="start" x="3618.5" y="-1091.3" font-family="Times,serif" font-size="14.00">Temporal</text>
+<polyline fill="none" stroke="black" points="3246,-1083.5 4058,-1083.5 "/>
+<text text-anchor="start" x="3586" y="-1068.3" font-family="Times,serif" font-size="14.00">_end : datetime</text>
+<text text-anchor="start" x="3586" y="-1053.3" font-family="Times,serif" font-size="14.00">_start : datetime</text>
+<text text-anchor="start" x="3586" y="-1038.3" font-family="Times,serif" font-size="14.00">end : dt.datetime</text>
+<text text-anchor="start" x="3586" y="-1023.3" font-family="Times,serif" font-size="14.00">start : dt.datetime</text>
+<polyline fill="none" stroke="black" points="3246,-1015.5 4058,-1015.5 "/>
+<text text-anchor="start" x="3254" y="-1000.3" font-family="Times,serif" font-size="14.00">__init__(date_range: Union[list, dict], start_time: Union[str, dt.time, None], end_time: Union[str, dt.time, None])</text>
+<text text-anchor="start" x="3254" y="-985.3" font-family="Times,serif" font-size="14.00">__str__(): str</text>
 </g>
 <!-- icepyx.core.temporal.Temporal&#45;&gt;icepyx.core.query.GenQuery -->
 <g id="edge17" class="edge">
 <title>icepyx.core.temporal.Temporal&#45;&gt;icepyx.core.query.GenQuery</title>
-<path fill="none" stroke="black" d="M3533.31,-1106.52C3452.39,-1171.75 3319.55,-1273.82 3195,-1347 3165.67,-1364.23 3133.94,-1380.9 3102.29,-1396.43"/>
-<polygon fill="black" stroke="black" points="3101.89,-1396.62 3098.25,-1402.84 3091.1,-1401.87 3094.75,-1395.65 3101.89,-1396.62"/>
-<text text-anchor="middle" x="3199" y="-1368.8" font-family="Times,serif" font-size="14.00" fill="green">_temporal</text>
+<path fill="none" stroke="black" d="M3575.31,-1106.52C3494.39,-1171.75 3361.55,-1273.82 3237,-1347 3207.67,-1364.23 3175.94,-1380.9 3144.29,-1396.43"/>
+<polygon fill="black" stroke="black" points="3143.89,-1396.62 3140.25,-1402.84 3133.1,-1401.87 3136.75,-1395.65 3143.89,-1396.62"/>
+<text text-anchor="middle" x="3241" y="-1368.8" font-family="Times,serif" font-size="14.00" fill="green">_temporal</text>
 </g>
 <!-- icepyx.core.variables.Variables -->
 <g id="node23" class="node">
@@ -517,8 +517,8 @@
 <!-- icepyx.core.variables.Variables&#45;&gt;icepyx.core.query.Query -->
 <g id="edge18" class="edge">
 <title>icepyx.core.variables.Variables&#45;&gt;icepyx.core.query.Query</title>
-<path fill="none" stroke="black" d="M1294.3,-685.5C1311.86,-697.24 1329.57,-708.57 1347,-719 1445.74,-778.12 1557.02,-835 1660.23,-884.06"/>
-<polygon fill="black" stroke="black" points="1660.31,-884.1 1667.45,-883.05 1671.16,-889.24 1664.02,-890.28 1660.31,-884.1"/>
+<path fill="none" stroke="black" d="M1294.21,-685.65C1311.79,-697.36 1329.53,-708.63 1347,-719 1441.17,-774.88 1546.63,-828.42 1646.12,-875.26"/>
+<polygon fill="black" stroke="black" points="1646.41,-875.4 1653.55,-874.32 1657.28,-880.49 1650.15,-881.57 1646.41,-875.4"/>
 <text text-anchor="middle" x="1383.5" y="-707.8" font-family="Times,serif" font-size="14.00" fill="green">_variables</text>
 </g>
 <!-- icepyx.core.variables.Variables&#45;&gt;icepyx.core.read.Read -->

--- a/doc/source/user_guide/documentation/classes_user_uml.svg
+++ b/doc/source/user_guide/documentation/classes_user_uml.svg
@@ -60,39 +60,39 @@
 <!-- icepyx.core.query.Query -->
 <g id="node14" class="node">
 <title>icepyx.core.query.Query</title>
-<polygon fill="none" stroke="black" points="1052,-527.5 1052,-896.5 1569,-896.5 1569,-527.5 1052,-527.5"/>
-<text text-anchor="start" x="1288.5" y="-881.3" font-family="Times,serif" font-size="14.00">Query</text>
-<polyline fill="none" stroke="black" points="1052,-873.5 1569,-873.5 "/>
-<text text-anchor="start" x="1148" y="-858.3" font-family="Times,serif" font-size="14.00">CMRparams : CMRParams</text>
-<text text-anchor="start" x="1148" y="-843.3" font-family="Times,serif" font-size="14.00">REQUEST_RETRY_INTERVAL_SECONDS : int</text>
-<text text-anchor="start" x="1148" y="-828.3" font-family="Times,serif" font-size="14.00">concept_id : Union[str, None]</text>
-<text text-anchor="start" x="1148" y="-813.3" font-family="Times,serif" font-size="14.00">cycles</text>
-<text text-anchor="start" x="1148" y="-798.3" font-family="Times,serif" font-size="14.00">granules</text>
-<text text-anchor="start" x="1148" y="-783.3" font-family="Times,serif" font-size="14.00">harmony_api</text>
-<text text-anchor="start" x="1148" y="-768.3" font-family="Times,serif" font-size="14.00">last_order</text>
-<text text-anchor="start" x="1148" y="-753.3" font-family="Times,serif" font-size="14.00">order_vars : Union[Variables, None]</text>
-<text text-anchor="start" x="1148" y="-738.3" font-family="Times,serif" font-size="14.00">product</text>
-<text text-anchor="start" x="1148" y="-723.3" font-family="Times,serif" font-size="14.00">product_version</text>
-<text text-anchor="start" x="1148" y="-708.3" font-family="Times,serif" font-size="14.00">tracks</text>
-<text text-anchor="start" x="1148" y="-693.3" font-family="Times,serif" font-size="14.00">variables : Variables</text>
-<polyline fill="none" stroke="black" points="1052,-685.5 1569,-685.5 "/>
-<text text-anchor="start" x="1060" y="-670.3" font-family="Times,serif" font-size="14.00">avail_granules(ids, cycles, tracks, cloud)</text>
-<text text-anchor="start" x="1060" y="-655.3" font-family="Times,serif" font-size="14.00">download_granules(path: Path, overwrite: bool): Union[list[str], None]</text>
-<text text-anchor="start" x="1060" y="-640.3" font-family="Times,serif" font-size="14.00">latest_version()</text>
-<text text-anchor="start" x="1060" y="-625.3" font-family="Times,serif" font-size="14.00">order_granules(subset: bool, skip_preview: bool): DataOrder</text>
-<text text-anchor="start" x="1060" y="-610.3" font-family="Times,serif" font-size="14.00">product_all_info()</text>
-<text text-anchor="start" x="1060" y="-595.3" font-family="Times,serif" font-size="14.00">product_summary_info()</text>
-<text text-anchor="start" x="1060" y="-580.3" font-family="Times,serif" font-size="14.00">show_custom_options(): Dict[str, Any]</text>
-<text text-anchor="start" x="1060" y="-565.3" font-family="Times,serif" font-size="14.00">skip_preview()</text>
-<text text-anchor="start" x="1060" y="-550.3" font-family="Times,serif" font-size="14.00">visualize_elevation()</text>
-<text text-anchor="start" x="1060" y="-535.3" font-family="Times,serif" font-size="14.00">visualize_spatial_extent()</text>
+<polygon fill="none" stroke="black" points="832,-527.5 832,-896.5 1585,-896.5 1585,-527.5 832,-527.5"/>
+<text text-anchor="start" x="1186.5" y="-881.3" font-family="Times,serif" font-size="14.00">Query</text>
+<polyline fill="none" stroke="black" points="832,-873.5 1585,-873.5 "/>
+<text text-anchor="start" x="1046" y="-858.3" font-family="Times,serif" font-size="14.00">CMRparams : CMRParams</text>
+<text text-anchor="start" x="1046" y="-843.3" font-family="Times,serif" font-size="14.00">REQUEST_RETRY_INTERVAL_SECONDS : int</text>
+<text text-anchor="start" x="1046" y="-828.3" font-family="Times,serif" font-size="14.00">concept_id : Union[str, None]</text>
+<text text-anchor="start" x="1046" y="-813.3" font-family="Times,serif" font-size="14.00">cycles</text>
+<text text-anchor="start" x="1046" y="-798.3" font-family="Times,serif" font-size="14.00">granules</text>
+<text text-anchor="start" x="1046" y="-783.3" font-family="Times,serif" font-size="14.00">harmony_api</text>
+<text text-anchor="start" x="1046" y="-768.3" font-family="Times,serif" font-size="14.00">last_order</text>
+<text text-anchor="start" x="1046" y="-753.3" font-family="Times,serif" font-size="14.00">order_vars : Union[Variables, None]</text>
+<text text-anchor="start" x="1046" y="-738.3" font-family="Times,serif" font-size="14.00">product</text>
+<text text-anchor="start" x="1046" y="-723.3" font-family="Times,serif" font-size="14.00">product_version</text>
+<text text-anchor="start" x="1046" y="-708.3" font-family="Times,serif" font-size="14.00">tracks</text>
+<text text-anchor="start" x="1046" y="-693.3" font-family="Times,serif" font-size="14.00">variables : Variables</text>
+<polyline fill="none" stroke="black" points="832,-685.5 1585,-685.5 "/>
+<text text-anchor="start" x="840" y="-670.3" font-family="Times,serif" font-size="14.00">avail_granules(ids, cycles, tracks, cloud)</text>
+<text text-anchor="start" x="840" y="-655.3" font-family="Times,serif" font-size="14.00">download_granules(path: Path, overwrite: bool, subset: bool, skip_preview: bool): Union[list[str], None]</text>
+<text text-anchor="start" x="840" y="-640.3" font-family="Times,serif" font-size="14.00">latest_version()</text>
+<text text-anchor="start" x="840" y="-625.3" font-family="Times,serif" font-size="14.00">order_granules(subset: bool, skip_preview: bool): DataOrder</text>
+<text text-anchor="start" x="840" y="-610.3" font-family="Times,serif" font-size="14.00">product_all_info()</text>
+<text text-anchor="start" x="840" y="-595.3" font-family="Times,serif" font-size="14.00">product_summary_info()</text>
+<text text-anchor="start" x="840" y="-580.3" font-family="Times,serif" font-size="14.00">show_custom_options(): Dict[str, Any]</text>
+<text text-anchor="start" x="840" y="-565.3" font-family="Times,serif" font-size="14.00">skip_preview()</text>
+<text text-anchor="start" x="840" y="-550.3" font-family="Times,serif" font-size="14.00">visualize_elevation()</text>
+<text text-anchor="start" x="840" y="-535.3" font-family="Times,serif" font-size="14.00">visualize_spatial_extent()</text>
 </g>
 <!-- icepyx.core.orders.DataOrder&#45;&gt;icepyx.core.query.Query -->
 <g id="edge11" class="edge">
 <title>icepyx.core.orders.DataOrder&#45;&gt;icepyx.core.query.Query</title>
-<path fill="none" stroke="black" d="M751.52,-471.92C754.53,-473.29 757.53,-474.65 760.5,-476 851.19,-517.06 951.1,-560.33 1040.59,-598.39"/>
-<polygon fill="black" stroke="black" points="1040.69,-598.43 1047.78,-597.1 1051.74,-603.13 1044.65,-604.46 1040.69,-598.43"/>
-<text text-anchor="middle" x="857" y="-497.8" font-family="Times,serif" font-size="14.00" fill="green">last_order</text>
+<path fill="none" stroke="black" d="M746.97,-475.69C775.92,-490.45 806.48,-506.03 837.54,-521.87"/>
+<polygon fill="black" stroke="black" points="837.85,-522.03 845.02,-521.19 848.54,-527.48 841.38,-528.32 837.85,-522.03"/>
+<text text-anchor="middle" x="837" y="-497.8" font-family="Times,serif" font-size="14.00" fill="green">last_order</text>
 </g>
 <!-- icepyx.core.exceptions.DeprecationError -->
 <g id="node5" class="node">
@@ -106,14 +106,14 @@
 <!-- icepyx.core.auth.EarthdataAuthMixin -->
 <g id="node6" class="node">
 <title>icepyx.core.auth.EarthdataAuthMixin</title>
-<polygon fill="none" stroke="black" points="1585,-957 1585,-1056 1748,-1056 1748,-957 1585,-957"/>
-<text text-anchor="start" x="1593" y="-1040.8" font-family="Times,serif" font-size="14.00">EarthdataAuthMixin</text>
-<polyline fill="none" stroke="black" points="1585,-1033 1748,-1033 "/>
-<text text-anchor="start" x="1597" y="-1017.8" font-family="Times,serif" font-size="14.00">auth</text>
-<text text-anchor="start" x="1597" y="-1002.8" font-family="Times,serif" font-size="14.00">s3login_credentials</text>
-<text text-anchor="start" x="1597" y="-987.8" font-family="Times,serif" font-size="14.00">session</text>
-<polyline fill="none" stroke="black" points="1585,-980 1748,-980 "/>
-<text text-anchor="start" x="1664" y="-964.8" font-family="Times,serif" font-size="14.00"> </text>
+<polygon fill="none" stroke="black" points="1600,-957 1600,-1056 1763,-1056 1763,-957 1600,-957"/>
+<text text-anchor="start" x="1608" y="-1040.8" font-family="Times,serif" font-size="14.00">EarthdataAuthMixin</text>
+<polyline fill="none" stroke="black" points="1600,-1033 1763,-1033 "/>
+<text text-anchor="start" x="1612" y="-1017.8" font-family="Times,serif" font-size="14.00">auth</text>
+<text text-anchor="start" x="1612" y="-1002.8" font-family="Times,serif" font-size="14.00">s3login_credentials</text>
+<text text-anchor="start" x="1612" y="-987.8" font-family="Times,serif" font-size="14.00">session</text>
+<polyline fill="none" stroke="black" points="1600,-980 1763,-980 "/>
+<text text-anchor="start" x="1679" y="-964.8" font-family="Times,serif" font-size="14.00"> </text>
 </g>
 <!-- icepyx.core.exceptions.ExhaustiveTypeGuardException -->
 <g id="node7" class="node">
@@ -142,17 +142,17 @@
 <!-- icepyx.core.query.GenQuery -->
 <g id="node8" class="node">
 <title>icepyx.core.query.GenQuery</title>
-<polygon fill="none" stroke="black" points="1162.5,-934.5 1162.5,-1078.5 1458.5,-1078.5 1458.5,-934.5 1162.5,-934.5"/>
-<text text-anchor="start" x="1274" y="-1063.3" font-family="Times,serif" font-size="14.00">GenQuery</text>
-<polyline fill="none" stroke="black" points="1162.5,-1055.5 1458.5,-1055.5 "/>
-<text text-anchor="start" x="1170.5" y="-1040.3" font-family="Times,serif" font-size="14.00">dates : list[str]</text>
-<text text-anchor="start" x="1170.5" y="-1025.3" font-family="Times,serif" font-size="14.00">end_time : Union[list[str], str]</text>
-<text text-anchor="start" x="1170.5" y="-1010.3" font-family="Times,serif" font-size="14.00">spatial</text>
-<text text-anchor="start" x="1170.5" y="-995.3" font-family="Times,serif" font-size="14.00">spatial_extent</text>
-<text text-anchor="start" x="1170.5" y="-980.3" font-family="Times,serif" font-size="14.00">start_time : Union[list[str], str]</text>
-<text text-anchor="start" x="1170.5" y="-965.3" font-family="Times,serif" font-size="14.00">temporal : Union[tp.Temporal, list[str]]</text>
-<polyline fill="none" stroke="black" points="1162.5,-957.5 1458.5,-957.5 "/>
-<text text-anchor="start" x="1308" y="-942.3" font-family="Times,serif" font-size="14.00"> </text>
+<polygon fill="none" stroke="black" points="1060.5,-934.5 1060.5,-1078.5 1356.5,-1078.5 1356.5,-934.5 1060.5,-934.5"/>
+<text text-anchor="start" x="1172" y="-1063.3" font-family="Times,serif" font-size="14.00">GenQuery</text>
+<polyline fill="none" stroke="black" points="1060.5,-1055.5 1356.5,-1055.5 "/>
+<text text-anchor="start" x="1068.5" y="-1040.3" font-family="Times,serif" font-size="14.00">dates : list[str]</text>
+<text text-anchor="start" x="1068.5" y="-1025.3" font-family="Times,serif" font-size="14.00">end_time : Union[list[str], str]</text>
+<text text-anchor="start" x="1068.5" y="-1010.3" font-family="Times,serif" font-size="14.00">spatial</text>
+<text text-anchor="start" x="1068.5" y="-995.3" font-family="Times,serif" font-size="14.00">spatial_extent</text>
+<text text-anchor="start" x="1068.5" y="-980.3" font-family="Times,serif" font-size="14.00">start_time : Union[list[str], str]</text>
+<text text-anchor="start" x="1068.5" y="-965.3" font-family="Times,serif" font-size="14.00">temporal : Union[tp.Temporal, list[str]]</text>
+<polyline fill="none" stroke="black" points="1060.5,-957.5 1356.5,-957.5 "/>
+<text text-anchor="start" x="1206" y="-942.3" font-family="Times,serif" font-size="14.00"> </text>
 </g>
 <!-- icepyx.core.granules.Granules -->
 <g id="node9" class="node">
@@ -176,8 +176,8 @@
 <!-- icepyx.core.granules.Granules&#45;&gt;icepyx.core.auth.EarthdataAuthMixin -->
 <g id="edge3" class="edge">
 <title>icepyx.core.granules.Granules&#45;&gt;icepyx.core.auth.EarthdataAuthMixin</title>
-<path fill="none" stroke="black" d="M1220.9,-143.93C1610.41,-184.97 2220.66,-252.02 2237.5,-271 2359.86,-408.9 2174.98,-835.02 2109.5,-897 2059.47,-944.35 1872.8,-977.46 1758.34,-993.81"/>
-<polygon fill="none" stroke="black" points="1757.59,-990.38 1748.18,-995.25 1758.57,-997.31 1757.59,-990.38"/>
+<path fill="none" stroke="black" d="M1220.9,-143.93C1610.41,-184.97 2220.66,-252.02 2237.5,-271 2352.39,-400.48 2194.52,-828.51 2124.5,-897 2075.25,-945.17 1888.3,-977.98 1773.58,-994.06"/>
+<polygon fill="none" stroke="black" points="1772.82,-990.63 1763.4,-995.47 1773.78,-997.57 1772.82,-990.63"/>
 </g>
 <!-- icepyx.core.harmony.HarmonyApi -->
 <g id="node10" class="node">
@@ -199,15 +199,15 @@
 <!-- icepyx.core.harmony.HarmonyApi&#45;&gt;icepyx.core.auth.EarthdataAuthMixin -->
 <g id="edge4" class="edge">
 <title>icepyx.core.harmony.HarmonyApi&#45;&gt;icepyx.core.auth.EarthdataAuthMixin</title>
-<path fill="none" stroke="black" d="M1550.4,-460.5C1560.94,-481.63 1570.85,-504.62 1577.5,-527 1624.61,-685.5 1572.65,-737.57 1616.5,-897 1621.17,-913.97 1628.23,-931.61 1635.59,-947.61"/>
-<polygon fill="none" stroke="black" points="1632.51,-949.28 1639.95,-956.82 1638.84,-946.29 1632.51,-949.28"/>
+<path fill="none" stroke="black" d="M1561.81,-460.65C1574.23,-481.49 1585.8,-504.32 1593.5,-527 1646.66,-683.53 1587.87,-737.55 1631.5,-897 1636.14,-913.97 1643.2,-931.62 1650.56,-947.62"/>
+<polygon fill="none" stroke="black" points="1647.48,-949.28 1654.92,-956.83 1653.81,-946.29 1647.48,-949.28"/>
 </g>
 <!-- icepyx.core.harmony.HarmonyApi&#45;&gt;icepyx.core.query.Query -->
 <g id="edge10" class="edge">
 <title>icepyx.core.harmony.HarmonyApi&#45;&gt;icepyx.core.query.Query</title>
-<path fill="none" stroke="black" d="M1451.07,-460.72C1441.25,-478.22 1430.54,-497.28 1419.56,-516.82"/>
-<polygon fill="black" stroke="black" points="1419.5,-516.94 1420.05,-524.13 1413.62,-527.4 1413.07,-520.21 1419.5,-516.94"/>
-<text text-anchor="middle" x="1473.5" y="-497.8" font-family="Times,serif" font-size="14.00" fill="green">harmony_api</text>
+<path fill="none" stroke="black" d="M1424.94,-460.72C1409.46,-478.62 1392.56,-498.16 1375.25,-518.17"/>
+<polygon fill="black" stroke="black" points="1375.13,-518.32 1374.23,-525.48 1367.28,-527.4 1368.18,-520.24 1375.13,-518.32"/>
+<text text-anchor="middle" x="1435.5" y="-497.8" font-family="Times,serif" font-size="14.00" fill="green">harmony_api</text>
 </g>
 <!-- icepyx.core.harmony.HarmonyTemporal -->
 <g id="node11" class="node">
@@ -263,33 +263,33 @@
 <!-- icepyx.core.query.Query&#45;&gt;icepyx.core.auth.EarthdataAuthMixin -->
 <g id="edge5" class="edge">
 <title>icepyx.core.query.Query&#45;&gt;icepyx.core.auth.EarthdataAuthMixin</title>
-<path fill="none" stroke="black" d="M1533.94,-896.58C1557.51,-915.95 1579.95,-934.39 1599.43,-950.4"/>
-<polygon fill="none" stroke="black" points="1597.37,-953.23 1607.31,-956.87 1601.81,-947.82 1597.37,-953.23"/>
+<path fill="none" stroke="black" d="M1505.37,-896.58C1537.39,-916.38 1567.83,-935.2 1594.11,-951.46"/>
+<polygon fill="none" stroke="black" points="1592.52,-954.59 1602.86,-956.87 1596.2,-948.63 1592.52,-954.59"/>
 </g>
 <!-- icepyx.core.query.Query&#45;&gt;icepyx.core.query.GenQuery -->
 <g id="edge6" class="edge">
 <title>icepyx.core.query.Query&#45;&gt;icepyx.core.query.GenQuery</title>
-<path fill="none" stroke="black" d="M1310.5,-896.58C1310.5,-906.07 1310.5,-915.33 1310.5,-924.2"/>
-<polygon fill="none" stroke="black" points="1307,-924.41 1310.5,-934.41 1314,-924.41 1307,-924.41"/>
+<path fill="none" stroke="black" d="M1208.5,-896.58C1208.5,-906.07 1208.5,-915.33 1208.5,-924.2"/>
+<polygon fill="none" stroke="black" points="1205,-924.41 1208.5,-934.41 1212,-924.41 1205,-924.41"/>
 </g>
 <!-- icepyx.core.read.Read -->
 <g id="node16" class="node">
 <title>icepyx.core.read.Read</title>
-<polygon fill="none" stroke="black" points="1625.5,-655 1625.5,-769 1707.5,-769 1707.5,-655 1625.5,-655"/>
-<text text-anchor="start" x="1648" y="-753.8" font-family="Times,serif" font-size="14.00">Read</text>
-<polyline fill="none" stroke="black" points="1625.5,-746 1707.5,-746 "/>
-<text text-anchor="start" x="1633.5" y="-730.8" font-family="Times,serif" font-size="14.00">filelist</text>
-<text text-anchor="start" x="1633.5" y="-715.8" font-family="Times,serif" font-size="14.00">is_s3</text>
-<text text-anchor="start" x="1633.5" y="-700.8" font-family="Times,serif" font-size="14.00">product</text>
-<text text-anchor="start" x="1633.5" y="-685.8" font-family="Times,serif" font-size="14.00">variables</text>
-<polyline fill="none" stroke="black" points="1625.5,-678 1707.5,-678 "/>
-<text text-anchor="start" x="1646" y="-662.8" font-family="Times,serif" font-size="14.00">load()</text>
+<polygon fill="none" stroke="black" points="1640.5,-655 1640.5,-769 1722.5,-769 1722.5,-655 1640.5,-655"/>
+<text text-anchor="start" x="1663" y="-753.8" font-family="Times,serif" font-size="14.00">Read</text>
+<polyline fill="none" stroke="black" points="1640.5,-746 1722.5,-746 "/>
+<text text-anchor="start" x="1648.5" y="-730.8" font-family="Times,serif" font-size="14.00">filelist</text>
+<text text-anchor="start" x="1648.5" y="-715.8" font-family="Times,serif" font-size="14.00">is_s3</text>
+<text text-anchor="start" x="1648.5" y="-700.8" font-family="Times,serif" font-size="14.00">product</text>
+<text text-anchor="start" x="1648.5" y="-685.8" font-family="Times,serif" font-size="14.00">variables</text>
+<polyline fill="none" stroke="black" points="1640.5,-678 1722.5,-678 "/>
+<text text-anchor="start" x="1661" y="-662.8" font-family="Times,serif" font-size="14.00">load()</text>
 </g>
 <!-- icepyx.core.read.Read&#45;&gt;icepyx.core.auth.EarthdataAuthMixin -->
 <g id="edge7" class="edge">
 <title>icepyx.core.read.Read&#45;&gt;icepyx.core.auth.EarthdataAuthMixin</title>
-<path fill="none" stroke="black" d="M1666.5,-769.05C1666.5,-820.06 1666.5,-895.09 1666.5,-946.88"/>
-<polygon fill="none" stroke="black" points="1663,-946.92 1666.5,-956.92 1670,-946.92 1663,-946.92"/>
+<path fill="none" stroke="black" d="M1681.5,-769.05C1681.5,-820.06 1681.5,-895.09 1681.5,-946.88"/>
+<polygon fill="none" stroke="black" points="1678,-946.92 1681.5,-956.92 1685,-946.92 1678,-946.92"/>
 </g>
 <!-- icepyx.core.spatial.Spatial -->
 <g id="node17" class="node">
@@ -319,24 +319,24 @@
 <!-- icepyx.core.variables.Variables -->
 <g id="node20" class="node">
 <title>icepyx.core.variables.Variables</title>
-<polygon fill="none" stroke="black" points="1726,-632.5 1726,-791.5 2101,-791.5 2101,-632.5 1726,-632.5"/>
-<text text-anchor="start" x="1880" y="-776.3" font-family="Times,serif" font-size="14.00">Variables</text>
-<polyline fill="none" stroke="black" points="1726,-768.5 2101,-768.5 "/>
-<text text-anchor="start" x="1826" y="-753.3" font-family="Times,serif" font-size="14.00">path</text>
-<text text-anchor="start" x="1826" y="-738.3" font-family="Times,serif" font-size="14.00">product</text>
-<text text-anchor="start" x="1826" y="-723.3" font-family="Times,serif" font-size="14.00">version</text>
-<text text-anchor="start" x="1826" y="-708.3" font-family="Times,serif" font-size="14.00">wanted : NoneType, dict</text>
-<polyline fill="none" stroke="black" points="1726,-700.5 2101,-700.5 "/>
-<text text-anchor="start" x="1734" y="-685.3" font-family="Times,serif" font-size="14.00">append(defaults, var_list, beam_list, keyword_list)</text>
-<text text-anchor="start" x="1734" y="-670.3" font-family="Times,serif" font-size="14.00">avail(options, internal)</text>
-<text text-anchor="start" x="1734" y="-655.3" font-family="Times,serif" font-size="14.00">parse_var_list(varlist, tiered, tiered_vars)</text>
-<text text-anchor="start" x="1734" y="-640.3" font-family="Times,serif" font-size="14.00">remove(all, var_list, beam_list, keyword_list)</text>
+<polygon fill="none" stroke="black" points="1741,-632.5 1741,-791.5 2116,-791.5 2116,-632.5 1741,-632.5"/>
+<text text-anchor="start" x="1895" y="-776.3" font-family="Times,serif" font-size="14.00">Variables</text>
+<polyline fill="none" stroke="black" points="1741,-768.5 2116,-768.5 "/>
+<text text-anchor="start" x="1841" y="-753.3" font-family="Times,serif" font-size="14.00">path</text>
+<text text-anchor="start" x="1841" y="-738.3" font-family="Times,serif" font-size="14.00">product</text>
+<text text-anchor="start" x="1841" y="-723.3" font-family="Times,serif" font-size="14.00">version</text>
+<text text-anchor="start" x="1841" y="-708.3" font-family="Times,serif" font-size="14.00">wanted : NoneType, dict</text>
+<polyline fill="none" stroke="black" points="1741,-700.5 2116,-700.5 "/>
+<text text-anchor="start" x="1749" y="-685.3" font-family="Times,serif" font-size="14.00">append(defaults, var_list, beam_list, keyword_list)</text>
+<text text-anchor="start" x="1749" y="-670.3" font-family="Times,serif" font-size="14.00">avail(options, internal)</text>
+<text text-anchor="start" x="1749" y="-655.3" font-family="Times,serif" font-size="14.00">parse_var_list(varlist, tiered, tiered_vars)</text>
+<text text-anchor="start" x="1749" y="-640.3" font-family="Times,serif" font-size="14.00">remove(all, var_list, beam_list, keyword_list)</text>
 </g>
 <!-- icepyx.core.variables.Variables&#45;&gt;icepyx.core.auth.EarthdataAuthMixin -->
 <g id="edge8" class="edge">
 <title>icepyx.core.variables.Variables&#45;&gt;icepyx.core.auth.EarthdataAuthMixin</title>
-<path fill="none" stroke="black" d="M1846.98,-791.77C1805.06,-841.41 1751.92,-904.34 1714.19,-949.03"/>
-<polygon fill="none" stroke="black" points="1711.34,-946.98 1707.56,-956.87 1716.69,-951.49 1711.34,-946.98"/>
+<path fill="none" stroke="black" d="M1861.98,-791.77C1820.06,-841.41 1766.92,-904.34 1729.19,-949.03"/>
+<polygon fill="none" stroke="black" points="1726.34,-946.98 1722.56,-956.87 1731.69,-951.49 1726.34,-946.98"/>
 </g>
 <!-- icepyx.core.visualization.Visualize -->
 <g id="node21" class="node">

--- a/icepyx/core/query.py
+++ b/icepyx/core/query.py
@@ -1001,6 +1001,8 @@ class Query(GenQuery, EarthdataAuthMixin):
         self,
         path: Path,
         overwrite: bool = False,
+        subset: bool = True,
+        skip_preview: bool = False,
     ) -> Union[list[str], None]:
         """
         Download the granules for the order, blocking until they are ready if necessary.
@@ -1011,6 +1013,15 @@ class Query(GenQuery, EarthdataAuthMixin):
             The directory where granules should be saved.
         overwrite : bool, optional
             Whether to overwrite existing files (default is False).
+        subset : bool, default True
+            Apply subsetting to the data order using harmony, returning only data that meets the
+            subset parameters. Spatial and temporal subsetting based on the input parameters happens
+            by default when subset=True, but additional subsetting options are available.
+            Spatial subsetting returns all data that are within the area of interest (but not complete
+            granules. This eliminates false-positive granules returned by the metadata-level search)
+        skip_preview : bool, default False
+            If True, bypass the preview state when we order subsetting queries that exceed 300 granules.
+
 
         Returns
         -------
@@ -1019,8 +1030,8 @@ class Query(GenQuery, EarthdataAuthMixin):
         """
         # Order granules based on user selections if restart is False and there
         # are no job IDs registered by the harmony API
-        if hasattr(self, "last_order") is None:
-            raise ValueError("No order has been placed yet.")
+        if not hasattr(self, "last_order"):
+            self.order_granules(subset=subset, skip_preview=skip_preview)
         status = self.last_order.status()
         if status["status"] == "running" or status["status"] == "accepted":
             print(

--- a/icepyx/tests/integration/test_query.py
+++ b/icepyx/tests/integration/test_query.py
@@ -62,6 +62,25 @@ def test_download_granules_without_subsetting(reg):
     ]
 
 
+@pytest.mark.downloads_data
+def test_download_granules_without_ordering(reg):
+    """
+    Test that granules are automatically ordered by the download function.
+    """
+    path = "./downloads"
+
+    files = reg.download_granules(path=path)
+    assert isinstance(files, list)
+    # check that there are the right number of files of the correct size
+    h5_paths = sorted(glob.glob(pathname=f"{path}/ATL06_201902*.h5"))
+    assert len(h5_paths) == 3
+    assert [os.path.getsize(filename=p) for p in h5_paths] == [
+        53228429,  # 50.8 MiB
+        65120027,  # 62.1 MiB
+        49749227,  # 47.4 MiB
+    ]
+
+
 def test_tracks_only():
     """
     Test that a Query can be created with only tracks specified (no cycles).


### PR DESCRIPTION
Several users (#666, #720) have reported issues with receiving errors when attempting to download data without first running `order_granules()`, a known issue documented in #688 and #699. This PR updates the download function to first order data if the user has not explicitly run the order function, returning to the intended behavior of icepyx in v1.