### PR TITLE
Update Discourse links with Github Discussions links

### DIFF
--- a/ATTRIBUTION.rst
+++ b/ATTRIBUTION.rst
@@ -102,7 +102,7 @@ This document is an effort to describe icepyx's policies, with an awareness that
 to accommodate community growth, best practices, and feedback.
 
 We do not attempt to identify contribution levels through the number of commits made to the repository (e.g. ``git shortlog -sne``)
-or active engagement on GitHub (e.g. through issues, discussions, and pull requests) and Discourse.
+or active engagement on GitHub (e.g. through issues, discussions, and pull requests).
 The latter is difficult to quantify, and the use of squash merges into the development branch can mask the relative complexity
 of various contributions and does not necessarily capture significant conceptual contributions.
 

--- a/README.rst
+++ b/README.rst
@@ -149,8 +149,7 @@ Contact
 Working with ICESat-2 data and have ideas you want to share?
 Have a great suggestion or recommendation of something you'd like to see
 implemented and want to find out if others would like that tool too?
-Come join the conversation at: https://discourse.pangeo.io/.
-Search for "icesat-2" under the "science" topic to find us.
+Come join the conversation in our `Github Discussions <https://github.com/icesat2py/icepyx/discussions>`_ .
 
 .. _`icepyx`: https://github.com/icesat2py/icepyx
 .. _`contribution guidelines`: ./doc/source/contributing/contribution_guidelines.rst

--- a/doc/source/community/contact.rst
+++ b/doc/source/community/contact.rst
@@ -3,7 +3,7 @@
 Contact Us
 ==========
 
-* Need help installing, running, or using `icepyx`? Ask for help on `Discourse <https://discourse.pangeo.io/c/science/icesat-2/16>`_ or `GitHub Discussions <https://github.com/icesat2py/icepyx/discussions>`_.
+* Need help installing, running, or using `icepyx`? Ask for help through `GitHub Discussions <https://github.com/icesat2py/icepyx/discussions>`_.
 * Found a bug? Post an issue on `GitHub <https://github.com/icesat2py/icepyx/issues>`_!
 * Want to request or contribute a feature? Share your idea on `GitHub Discussions <https://github.com/icesat2py/icepyx/discussions>`_.
 * Have a question or want to know more? Join us for a virtual meeting (see below).

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -143,8 +143,8 @@ html_context = {
             "https://github.com/icesat2py/icepyx",
         ),
         (
-            '<i class="fa fa-comments fa-fw"></i> Pangeo Discourse',
-            "https://discourse.pangeo.io/t/icepyx-python-tools-for-icesat-2-data/404/2",
+            '<i class="fa fa-comments fa-fw"></i> Github Discussions',
+            "https://github.com/icesat2py/icepyx/discussions",
         ),
     ],
 }

--- a/doc/source/contributing/contribution_guidelines.rst
+++ b/doc/source/contributing/contribution_guidelines.rst
@@ -34,7 +34,7 @@ Find the *Issues* tab at the top of GitHub repository and click the *New Issue* 
 Questions and Help
 ------------------
 
-Please do not create issues to ask for help. A faster way to reach the community is through our Science/ICESat-2 subcategory on the `Pangeo discourse <https://discourse.pangeo.io/c/science/icesat-2/16>`_ page. We are excited to have you join an existing conversation or start a new post! Please note that a GitHub login is required to post on the discourse page.
+Please do not create issues to ask for help. A faster way to reach the community is through `Github Discussions <https://github.com/icesat2py/icepyx/discussions>`_ page. We are excited to have you join an existing conversation or start a new post!
 
 Other Resources
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
This PR replaces all references to the Pangeo Discourse with links to the Github discussions page. 5 references to the Discourse were found by searching the repository.


closes #731 