### PR TITLE
Fix version query

### DIFF
--- a/icepyx/core/query.py
+++ b/icepyx/core/query.py
@@ -502,7 +502,7 @@ class Query(GenQuery, EarthdataAuthMixin):
 
         # dictionary of optional CMR parameters
         kwargs = {}
-        kwargs["concept_id"] = self._get_concept_id(self.product, None)
+        kwargs["concept_id"] = self._get_concept_id(self.product, self._version)
 
         # temporal CMR parameters
         if hasattr(self, "_temporal") and self.product != "ATL11" and self._temporal:

--- a/icepyx/core/query.py
+++ b/icepyx/core/query.py
@@ -502,7 +502,7 @@ class Query(GenQuery, EarthdataAuthMixin):
 
         # dictionary of optional CMR parameters
         kwargs = {}
-        kwargs["concept_id"] = self._get_concept_id(self.product, self._version)
+        kwargs["concept_id"] = self._get_concept_id(self.product, None)
 
         # temporal CMR parameters
         if hasattr(self, "_temporal") and self.product != "ATL11" and self._temporal:

--- a/icepyx/core/types.py
+++ b/icepyx/core/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal, Optional, TypedDict, Union
+from typing import Literal, TypedDict, Union
 
 from typing_extensions import NotRequired
 
@@ -32,7 +32,7 @@ ICESat2ProductShortName = Literal[
 CMRParamsBase = TypedDict(
     "CMRParamsBase",
     {
-        "concept_id": Optional[str],
+        "concept_id": NotRequired[str],
         "temporal": NotRequired[str],
         "options[readable_granule_name][pattern]": NotRequired[str],
         "options[spatial][or]": NotRequired[str],

--- a/icepyx/core/types.py
+++ b/icepyx/core/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal, TypedDict, Union
+from typing import Literal, Optional, TypedDict, Union
 
 from typing_extensions import NotRequired
 
@@ -32,6 +32,7 @@ ICESat2ProductShortName = Literal[
 CMRParamsBase = TypedDict(
     "CMRParamsBase",
     {
+        "concept_id": Optional[str],
         "temporal": NotRequired[str],
         "options[readable_granule_name][pattern]": NotRequired[str],
         "options[spatial][or]": NotRequired[str],

--- a/icepyx/tests/unit/test_query.py
+++ b/icepyx/tests/unit/test_query.py
@@ -49,3 +49,49 @@ def test_temporal_properties_cycles_tracks():
     )
     exp = ["No temporal parameters set"]
     assert [obs == exp for obs in (reg_a.dates, reg_a.start_time, reg_a.end_time)]
+
+
+def test_cmrparams_concept_id_matches_version():
+    """
+    Test that CMRparams uses the correct concept_id for the specified version.
+    This test ensures that when building CMR search parameters, the concept_id
+    retrieved matches the query's product version. A mismatch would result in
+    querying granules from the wrong version.
+
+    Regression test for: https://github.com/icesat2py/icepyx/issues/XXX
+    When version=None was passed to _get_concept_id, earthaccess would return
+    the first available collection, causing version 006 to be used instead of
+    the intended version 007 or user-specified version.
+    """
+    # Concept IDs for ATL06 versions
+    v006_concept_id = "C2670138092-NSIDC_CPRD"
+    v007_concept_id = "C3564876127-NSIDC_CPRD"
+
+    # Test 1: Explicit version 006
+    reg_v006 = ipx.Query(
+        "ATL06",
+        [-45, 58, -35, 75],
+        ["2019-11-30", "2019-11-30"],
+        version="006",
+    )
+    assert reg_v006.product_version == "006"
+    assert reg_v006.CMRparams["concept_id"] == v006_concept_id
+
+    # Test 2: Explicit version 007
+    reg_v007 = ipx.Query(
+        "ATL06",
+        [-45, 58, -35, 75],
+        ["2019-11-30", "2019-11-30"],
+        version="007",
+    )
+    assert reg_v007.product_version == "007"
+    assert reg_v007.CMRparams["concept_id"] == v007_concept_id
+
+    # Test 3: Default version (should use latest, which is 007)
+    reg_default = ipx.Query(
+        "ATL06",
+        [-45, 58, -35, 75],
+        ["2019-11-30", "2019-11-30"],
+    )
+    assert reg_default.product_version == "007"
+    assert reg_default.CMRparams["concept_id"] == v007_concept_id

--- a/icepyx/tests/unit/test_query.py
+++ b/icepyx/tests/unit/test_query.py
@@ -60,34 +60,38 @@ def test_cmrparams_concept_id_matches_version():
     Regression test for: https://github.com/icesat2py/icepyx/issues/723
     """
     # Concept IDs for ATL06 versions
-    v006_concept_id = "C2670138092-NSIDC_CPRD"
-    v007_concept_id = "C3564876127-NSIDC_CPRD"
+    vprev_concept_id = "C2670138092-NSIDC_CPRD" # v006
+    vcurr_concept_id = "C3564876127-NSIDC_CPRD" # v007
 
-    # Test 1: Explicit version 006
-    reg_v006 = ipx.Query(
+    # Previous and Current version numbers
+    vprev = "006"
+    vcurr = "007"
+
+    # Test 1: Explicit previous version
+    reg_vprev = ipx.Query(
         "ATL06",
         [-45, 58, -35, 75],
         ["2019-11-30", "2019-11-30"],
-        version="006",
+        version=vprev,
     )
-    assert reg_v006.product_version == "006"
-    assert reg_v006.CMRparams["concept_id"] == v006_concept_id
+    assert reg_vprev.product_version == vprev
+    assert reg_vprev.CMRparams["concept_id"] == vprev_concept_id
 
-    # Test 2: Explicit version 007
-    reg_v007 = ipx.Query(
+    # Test 2: Explicit current version
+    reg_vcurr = ipx.Query(
         "ATL06",
         [-45, 58, -35, 75],
         ["2019-11-30", "2019-11-30"],
-        version="007",
+        version=vcurr,
     )
-    assert reg_v007.product_version == "007"
-    assert reg_v007.CMRparams["concept_id"] == v007_concept_id
+    assert reg_vcurr.product_version == vcurr
+    assert reg_vcurr.CMRparams["concept_id"] == vcurr_concept_id
 
-    # Test 3: Default version (should use latest, which is 007)
+    # Test 3: Default version (should use latest)
     reg_default = ipx.Query(
         "ATL06",
         [-45, 58, -35, 75],
         ["2019-11-30", "2019-11-30"],
     )
-    assert reg_default.product_version == "007"
-    assert reg_default.CMRparams["concept_id"] == v007_concept_id
+    assert reg_default.product_version == vcurr
+    assert reg_default.CMRparams["concept_id"] == vcurr_concept_id

--- a/icepyx/tests/unit/test_query.py
+++ b/icepyx/tests/unit/test_query.py
@@ -54,14 +54,10 @@ def test_temporal_properties_cycles_tracks():
 def test_cmrparams_concept_id_matches_version():
     """
     Test that CMRparams uses the correct concept_id for the specified version.
-    This test ensures that when building CMR search parameters, the concept_id
-    retrieved matches the query's product version. A mismatch would result in
-    querying granules from the wrong version.
+    Ensures that when building CMR search parameters, the concept_id retrieved matches the query's product version.
+    A mismatch would result in querying granules from the wrong version (e.g. the first listed).
 
-    Regression test for: https://github.com/icesat2py/icepyx/issues/XXX
-    When version=None was passed to _get_concept_id, earthaccess would return
-    the first available collection, causing version 006 to be used instead of
-    the intended version 007 or user-specified version.
+    Regression test for: https://github.com/icesat2py/icepyx/issues/723
     """
     # Concept IDs for ATL06 versions
     v006_concept_id = "C2670138092-NSIDC_CPRD"


### PR DESCRIPTION
By default we should use the most recent version for ATL datasets, this PR fixes a bug that will use the first version returned by CMR (which most times is V006). 