### PR TITLE
add zizmor security GH action

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,28 @@
+name: "GitHub Actions Security Analysis with zizmor 🌈"
+
+on:
+  push:
+    branches:
+      - "development"
+    paths:
+      - ".github/workflows/*"
+  pull_request:
+    paths:
+      - ".github/workflows/*"
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: "Run zizmor 🌈"
+    runs-on: "ubuntu-latest"
+    permissions:
+      security-events: "write" # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+    steps:
+      - name: "Checkout repository"
+        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: "Run zizmor 🌈"
+        uses: "zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8" # v0.5.2

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,9 +5,11 @@ on:
     branches:
       - "development"
     paths:
+      - ".github/dependabot.yml"
       - ".github/workflows/*"
   pull_request:
     paths:
+      - ".github/dependabot.yml"
       - ".github/workflows/*"
 
 permissions: {}


### PR DESCRIPTION
Thanks to @mfisher87 for creating this workflow for earthaccess and pointing me towards it to enhance our GitHub action security.