### PR TITLE
add _is_gridded attribute to read class

### DIFF
--- a/doc/source/user_guide/documentation/classes_dev_uml.svg
+++ b/doc/source/user_guide/documentation/classes_dev_uml.svg
@@ -407,31 +407,32 @@
 <!-- icepyx.core.read.Read -->
 <g id="node19" class="node">
 <title>icepyx.core.read.Read</title>
-<polygon fill="none" stroke="black" points="761,-910 761,-1174 1301,-1174 1301,-910 761,-910"/>
-<text text-anchor="start" x="1012.5" y="-1158.8" font-family="Times,serif" font-size="14.00">Read</text>
-<polyline fill="none" stroke="black" points="761,-1151 1301,-1151 "/>
-<text text-anchor="start" x="967" y="-1135.8" font-family="Times,serif" font-size="14.00">_filelist</text>
-<text text-anchor="start" x="967" y="-1120.8" font-family="Times,serif" font-size="14.00">_out_obj : Dataset</text>
-<text text-anchor="start" x="967" y="-1105.8" font-family="Times,serif" font-size="14.00">_product</text>
-<text text-anchor="start" x="967" y="-1090.8" font-family="Times,serif" font-size="14.00">_read_vars</text>
-<text text-anchor="start" x="967" y="-1075.8" font-family="Times,serif" font-size="14.00">filelist</text>
-<text text-anchor="start" x="967" y="-1060.8" font-family="Times,serif" font-size="14.00">is_s3</text>
-<text text-anchor="start" x="967" y="-1045.8" font-family="Times,serif" font-size="14.00">product</text>
-<text text-anchor="start" x="967" y="-1030.8" font-family="Times,serif" font-size="14.00">variables</text>
-<polyline fill="none" stroke="black" points="761,-1023 1301,-1023 "/>
-<text text-anchor="start" x="769" y="-1007.8" font-family="Times,serif" font-size="14.00">__init__(data_source, glob_kwargs, out_obj_type)</text>
-<text text-anchor="start" x="769" y="-992.8" font-family="Times,serif" font-size="14.00">_add_vars_to_ds(is2ds, ds, grp_path, wanted_groups_tiered, wanted_dict)</text>
-<text text-anchor="start" x="769" y="-977.8" font-family="Times,serif" font-size="14.00">_build_dataset_template(file)</text>
-<text text-anchor="start" x="769" y="-962.8" font-family="Times,serif" font-size="14.00">_build_single_file_dataset(file, groups_list)</text>
-<text text-anchor="start" x="769" y="-947.8" font-family="Times,serif" font-size="14.00">_combine_nested_vars(is2ds, ds, grp_path, wanted_dict)</text>
-<text text-anchor="start" x="769" y="-932.8" font-family="Times,serif" font-size="14.00">_read_single_grp(file, grp_path)</text>
-<text text-anchor="start" x="769" y="-917.8" font-family="Times,serif" font-size="14.00">load()</text>
+<polygon fill="none" stroke="black" points="761,-902.5 761,-1181.5 1301,-1181.5 1301,-902.5 761,-902.5"/>
+<text text-anchor="start" x="1012.5" y="-1166.3" font-family="Times,serif" font-size="14.00">Read</text>
+<polyline fill="none" stroke="black" points="761,-1158.5 1301,-1158.5 "/>
+<text text-anchor="start" x="967" y="-1143.3" font-family="Times,serif" font-size="14.00">_filelist</text>
+<text text-anchor="start" x="967" y="-1128.3" font-family="Times,serif" font-size="14.00">_is_gridded : bool</text>
+<text text-anchor="start" x="967" y="-1113.3" font-family="Times,serif" font-size="14.00">_out_obj : Dataset</text>
+<text text-anchor="start" x="967" y="-1098.3" font-family="Times,serif" font-size="14.00">_product</text>
+<text text-anchor="start" x="967" y="-1083.3" font-family="Times,serif" font-size="14.00">_read_vars</text>
+<text text-anchor="start" x="967" y="-1068.3" font-family="Times,serif" font-size="14.00">filelist</text>
+<text text-anchor="start" x="967" y="-1053.3" font-family="Times,serif" font-size="14.00">is_s3</text>
+<text text-anchor="start" x="967" y="-1038.3" font-family="Times,serif" font-size="14.00">product</text>
+<text text-anchor="start" x="967" y="-1023.3" font-family="Times,serif" font-size="14.00">variables</text>
+<polyline fill="none" stroke="black" points="761,-1015.5 1301,-1015.5 "/>
+<text text-anchor="start" x="769" y="-1000.3" font-family="Times,serif" font-size="14.00">__init__(data_source, glob_kwargs, out_obj_type)</text>
+<text text-anchor="start" x="769" y="-985.3" font-family="Times,serif" font-size="14.00">_add_vars_to_ds(is2ds, ds, grp_path, wanted_groups_tiered, wanted_dict)</text>
+<text text-anchor="start" x="769" y="-970.3" font-family="Times,serif" font-size="14.00">_build_dataset_template(file)</text>
+<text text-anchor="start" x="769" y="-955.3" font-family="Times,serif" font-size="14.00">_build_single_file_dataset(file, groups_list)</text>
+<text text-anchor="start" x="769" y="-940.3" font-family="Times,serif" font-size="14.00">_combine_nested_vars(is2ds, ds, grp_path, wanted_dict)</text>
+<text text-anchor="start" x="769" y="-925.3" font-family="Times,serif" font-size="14.00">_read_single_grp(file, grp_path)</text>
+<text text-anchor="start" x="769" y="-910.3" font-family="Times,serif" font-size="14.00">load()</text>
 </g>
 <!-- icepyx.core.read.Read&#45;&gt;icepyx.core.auth.EarthdataAuthMixin -->
 <g id="edge7" class="edge">
 <title>icepyx.core.read.Read&#45;&gt;icepyx.core.auth.EarthdataAuthMixin</title>
-<path fill="none" stroke="black" d="M1118,-1174.08C1165.43,-1245.54 1223.06,-1332.39 1266.11,-1397.24"/>
-<polygon fill="none" stroke="black" points="1263.37,-1399.44 1271.81,-1405.84 1269.2,-1395.57 1263.37,-1399.44"/>
+<path fill="none" stroke="black" d="M1123.04,-1181.68C1169.42,-1251.56 1224.46,-1334.49 1265.97,-1397.03"/>
+<polygon fill="none" stroke="black" points="1263.29,-1399.32 1271.74,-1405.72 1269.12,-1395.45 1263.29,-1399.32"/>
 </g>
 <!-- icepyx.core.spatial.Spatial -->
 <g id="node20" class="node">
@@ -524,8 +525,8 @@
 <!-- icepyx.core.variables.Variables&#45;&gt;icepyx.core.read.Read -->
 <g id="edge19" class="edge">
 <title>icepyx.core.variables.Variables&#45;&gt;icepyx.core.read.Read</title>
-<path fill="none" stroke="black" d="M1073.57,-685.75C1065.52,-752.98 1056.12,-831.39 1048.21,-897.41"/>
-<polygon fill="black" stroke="black" points="1048.18,-897.68 1051.43,-904.11 1046.75,-909.59 1043.49,-903.16 1048.18,-897.68"/>
+<path fill="none" stroke="black" d="M1073.57,-685.75C1065.8,-750.64 1056.77,-825.94 1049.04,-890.47"/>
+<polygon fill="black" stroke="black" points="1049.04,-890.47 1052.3,-896.91 1047.61,-902.39 1044.35,-895.95 1049.04,-890.47"/>
 <text text-anchor="middle" x="1109.5" y="-707.8" font-family="Times,serif" font-size="14.00" fill="green">_read_vars</text>
 </g>
 <!-- icepyx.core.visualization.Visualize -->

--- a/icepyx/core/read.py
+++ b/icepyx/core/read.py
@@ -268,6 +268,22 @@ class Read(EarthdataAuthMixin):
         # Assign the identified product to the property
         self._product = all_products[0]
 
+        # Level 3b, gridded (netcdf): ATL14, 15, 16, 17, 18, 19, 20, 21, 23
+        if self._product in [
+            "ATL14",
+            "ATL15",
+            "ATL16",
+            "ATL17",
+            "ATL18",
+            "ATL19",
+            "ATL20",
+            "ATL21",
+            "ATL23",
+        ]:
+            self._is_gridded = True
+        else:
+            self._is_gridded = False
+
         if out_obj_type is not None:
             print(
                 "Output object type will be an xarray DataSet - "
@@ -700,20 +716,8 @@ class Read(EarthdataAuthMixin):
         # DEVNOTE: elif does not actually apply wanted variable list,
         # and has not been tested for merging multiple files into one ds
         # of a gridded product
-        # TODO: all products need to be tested, and quicklook products added or explicitly excluded
-        # consider looking for netcdf file extension instead of using product
         # Level 3b, gridded (netcdf): ATL14, 15, 16, 17, 18, 19, 20, 21
-        if self.product in [
-            "ATL14",
-            "ATL15",
-            "ATL16",
-            "ATL17",
-            "ATL18",
-            "ATL19",
-            "ATL20",
-            "ATL21",
-            "ATL23",
-        ]:
+        if self._is_gridded:
             wanted_grouponly_set = set(wanted_groups_tiered[0])
             wanted_groups_list = sorted(wanted_grouponly_set)
             if len(wanted_groups_list) == 1:
@@ -759,7 +763,7 @@ class Read(EarthdataAuthMixin):
 
             return is2ds
 
-        # Level 2 and 3a Products: ATL03, 06, 07, 08, 09, 10, 12, 13
+        # Level 2 and 3a Products: ATL03, 06, 07, 08, 09, 10, 12, 13, 24
         else:
             is2ds = self._build_dataset_template(file)
 


### PR DESCRIPTION
Knowing if the ICESat-2 data product is gridded will be used to inform the appropriate read pathways (gridded products can easily and quickly be read into raster-based formats like Xarray DataArrays, whereas non-gridded products are more suited to table-based formats like Pandas DataFrames). This PR makes that information an attribute during the init so it is available throughout processing.