### PR TITLE
add pull request template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,6 @@ updates:
       interval: monthly
     ignore:
       - dependency-name: "sangonzal/repository-traffic-action"
-        versions: "v1"
+        versions: ["v1"]
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,6 @@ updates:
       interval: monthly
     ignore:
       - dependency-name: "sangonzal/repository-traffic-action"
-        versions: ["v1"]
+        versions: "v1"
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,6 @@ updates:
       interval: monthly
     ignore:
       - dependency-name: "sangonzal/repository-traffic-action"
-        versions: ["v1"]
+        versions: ["1.x"] # there was a mis-tag at some point, so the latest version is <1.x
     cooldown:
       default-days: 7

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,7 +34,7 @@ Please review our [How to Contribute](https://icepyx.readthedocs.io/en/latest/co
 
 
 #### Tips and Tricks
-Include `/binder` in a comment to add a Binder badge that will launch a binder notebook for the most recent commit in the PR.  
+Include `/binder` in a comment to add a [Binder](https://mybinder.readthedocs.io) badge that will launch a binder notebook for the most recent commit in the PR.  
 
 > **Need help?** We welcome contributions at every experience level. You don't have to
 > write tests alone — open your PR and ask for help. It's fine to let GitHub run tests

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,43 @@
+<!--
+IMPORTANT: Please open your PR in draft mode. Only mark it "Ready for review" after
+completing the "Ready for review" checklist.
+
+--->
+
+## Description
+
+<!--
+Replace this text, including the symbols above and below it, with descriptive text about
+the change you are proposing. Please include a reference to any issues/discussions addressed or resolved, for example "resolves #1".
+-->
+
+
+---
+
+#### "Ready for review" checklist
+<!--
+Please review our [How to Contribute](https://icepyx.readthedocs.io/en/latest/contributing/how_to_contribute.html) page for tips and tricks for contributing.
+-->
+
+- [ ] Place this Pull Request (PR) in draft until it is ready for review (see below)
+- [ ] PR title is descriptive
+- [ ] PR body contains links to related and resolved issues (e.g. `closes #1`)
+- [ ] If needed, docs and/or `README.md` updated
+- [ ] If needed, unit and/or integration tests added *(unsure how? see below!)*
+- [ ] Mark "ready for review"
+
+#### Review and merge checklist
+
+- [ ] All checks passing *(tip: comment `pre-commit.ci autofix` if pre-commit is failing)*
+- [ ] At least one approval
+- [ ] New contributors or contribution types acknowledged via `@all-contributors add @[GitHub_handle] for a, b, and c`
+
+
+#### Tips and Tricks
+Include `/binder` in a comment to add a Binder badge that will launch a binder notebook for the most recent commit in the PR.  
+
+> **Need help?** We welcome contributions at every experience level. You don't have to
+> write tests alone — open your PR and ask for help. It's fine to let GitHub run tests
+> for you, via [Continuous Integration (CI)](https://github.com/resources/articles/ci-cd),
+> instead of running them locally. If anything fails and you're not sure why, just
+> let us know in a comment and we'll work with you!


### PR DESCRIPTION
Adds a PR template, as discussed in [#756 comment](https://github.com/icesat2py/icepyx/pull/756#discussion_r3127033573), that provides a spot to document the new `\binder` comment required for adding a binder badge.

This PR template is based on the one used by [earthaccess](https://github.com/earthaccess-dev/earthaccess)