### PR TITLE
add ignore regex for long strings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ fallback_version = "unknown"
 
 [tool.codespell]
 ignore-words-list = "aas,socio-economic,toi"
+ignore-regex = "[A-Za-z0-9+/]{100,}" # Source - https://stackoverflow.com/a/78867222
 
 [tool.ruff]
 # DevGoal: Lint and format all Jupyter Notebooks, remove below.


### PR DESCRIPTION
## Description

Codespell often chokes when long hashes are included. This PR attempts to address that using the solution described [here](https://stackoverflow.com/questions/78867158/how-to-make-codespell-not-report-false-positives-in-base64-strings?answertab=scoredesc)


---

#### "Ready for review" checklist
<!--
Please review our [How to Contribute](https://icepyx.readthedocs.io/en/latest/contributing/how_to_contribute.html) page for tips and tricks for contributing.
-->

- [x] Place this Pull Request (PR) in draft until it is ready for review (see below)
- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit and/or integration tests added *(unsure how? see below!)*
- [x] Mark "ready for review"

#### Review and merge checklist

- [x] All checks passing *(tip: comment `pre-commit.ci autofix` if pre-commit is failing)*
- [ ] At least one approval
- [x] New contributors or contribution types acknowledged via `@all-contributors add @[GitHub_handle] for a, b, and c`


#### Tips and Tricks
Include `/binder` in a comment to add a [Binder](https://mybinder.readthedocs.io) badge that will launch a binder notebook for the most recent commit in the PR.  

> **Need help?** We welcome contributions at every experience level. You don't have to
> write tests alone — open your PR and ask for help. It's fine to let GitHub run tests
> for you, via [Continuous Integration (CI)](https://github.com/resources/articles/ci-cd),
> instead of running them locally. If anything fails and you're not sure why, just
> let us know in a comment and we'll work with you!
